### PR TITLE
Reference CLI app, integration tests, and E2E tests (#11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist/
 .env
 .env.*
 
+# CLI local data
+data/
+
 # Hardhat
 artifacts/
 cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,7 @@ registry.ts (depends on: crypto, NotifyProvider interface — no ethers, no Swar
 ## Maintenance Notes
 
 - If `contracts/SwarmNotificationRegistry.sol` changes, update the ABI and key values table in `README.md` to match.
+- When code or logic changes in any module (`src/`), check whether the **reference CLI app** (`examples/cli.ts`) and **all tests** (`test/`) need updating — this includes unit tests, integration tests (`test/integration.test.ts`), and E2E tests (`test/e2e.test.ts`).
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,20 @@ echo "DEPLOYER_PRIVATE_KEY=0x..." > .env
 npm run deploy -- --network gnosis
 ```
 
+## CLI Reference App
+
+A CLI tool for testing and demoing the full library. See [`examples/README.md`](./examples/README.md) for detailed usage.
+
+```bash
+# Quick start
+export PRIVATE_KEY=0x... BEE_URL=http://localhost:1633 STAMP=<batch-id>
+
+npm run cli -- identity publish
+npm run cli -- contacts add 0x... "Alice"
+npm run cli -- mailbox send 0x... -s "Hello" -b "Hi Alice!"
+npm run cli -- registry poll
+```
+
 ## Contributing
 
 - Every PR must include tests for new functionality

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,164 @@
+# Swarm Notify CLI — Reference App
+
+A CLI tool that exercises every module in the library. Used for manual testing, demos, and as an integration example.
+
+## Prerequisites
+
+- Node.js 18+
+- A running Bee node (light mode) on `localhost:1633`
+- A funded postage stamp batch ID
+- A secp256k1 private key
+
+## Setup
+
+```bash
+# From the project root
+npm install
+
+# Create .env with your config
+cat > .env << 'EOF'
+PRIVATE_KEY=0x<your-private-key>
+BEE_URL=http://localhost:1633
+STAMP=<your-postage-batch-id>
+GNOSIS_RPC_URL=https://rpc.gnosischain.com
+CONTRACT_ADDRESS=0x318aE190B77bA39fbcdFA4e84BB7CFD16b846Fcf
+EOF
+```
+
+## Commands
+
+```bash
+# Identity
+npm run cli -- identity publish              # Publish your identity feed
+npm run cli -- identity resolve <ethAddress>  # Look up someone's identity
+
+# Contacts
+npm run cli -- contacts add <ethAddress> <nickname>   # Add (resolves identity from Swarm)
+npm run cli -- contacts add <ethAddress> <nickname> \  # Add manually (no Bee needed)
+    --wallet-pub <hex> --overlay <hex>
+npm run cli -- contacts remove <ethAddress>           # Remove
+npm run cli -- contacts list                          # List all
+
+# Mailbox
+npm run cli -- mailbox send <ethAddress> -s "Subject" -b "Body"  # Send message
+npm run cli -- mailbox read <ethAddress>                          # Read from contact
+npm run cli -- mailbox inbox                                      # Check all contacts
+
+# Registry (on-chain notifications)
+npm run cli -- registry notify <ethAddress>      # Send first-contact notification
+npm run cli -- registry poll                     # Poll for notifications
+npm run cli -- registry poll --from-block 1000   # Poll from specific block
+```
+
+## Manual Test: Two-Terminal Demo
+
+This walks through the full notification flow with two identities.
+
+### Setup
+
+Open two terminals. Each represents a different user.
+
+**Terminal 1 (Alice):**
+```bash
+export PRIVATE_KEY=0x<alice-private-key>
+export BEE_URL=http://localhost:1633
+export STAMP=<stamp-id>
+```
+
+**Terminal 2 (Bob):**
+```bash
+export PRIVATE_KEY=0x<bob-private-key>
+export BEE_URL=http://localhost:1633
+export STAMP=<stamp-id>
+```
+
+### Steps
+
+1. **Alice publishes her identity:**
+   ```bash
+   # Terminal 1
+   npm run cli -- identity publish
+   # → Identity published for 0xAlice...
+   ```
+
+2. **Bob publishes his identity:**
+   ```bash
+   # Terminal 2
+   npm run cli -- identity publish
+   # → Identity published for 0xBob...
+   ```
+
+3. **Alice resolves Bob and adds as contact:**
+   ```bash
+   # Terminal 1
+   npm run cli -- identity resolve 0xBob...
+   npm run cli -- contacts add 0xBob... "Bob"
+   ```
+
+4. **Bob resolves Alice and adds as contact:**
+   ```bash
+   # Terminal 2
+   npm run cli -- identity resolve 0xAlice...
+   npm run cli -- contacts add 0xAlice... "Alice"
+   ```
+
+5. **Alice sends Bob a message:**
+   ```bash
+   # Terminal 1
+   npm run cli -- mailbox send 0xBob... -s "Project files" -b "Attached the latest version"
+   ```
+
+6. **Alice sends on-chain notification (first contact):**
+   ```bash
+   # Terminal 1
+   npm run cli -- registry notify 0xBob...
+   # → Notification sent, tx: 0x...
+   ```
+
+7. **Bob polls for notifications:**
+   ```bash
+   # Terminal 2
+   npm run cli -- registry poll
+   # → Found 1 notification: sender=0xAlice...
+   ```
+
+8. **Bob reads Alice's message:**
+   ```bash
+   # Terminal 2
+   npm run cli -- mailbox read 0xAlice...
+   # → [timestamp] Project files
+   #     Attached the latest version
+   ```
+
+9. **Bob replies:**
+   ```bash
+   # Terminal 2
+   npm run cli -- mailbox send 0xAlice... -s "Re: Project files" -b "Got it, thanks!"
+   ```
+
+10. **Alice checks inbox:**
+    ```bash
+    # Terminal 1
+    npm run cli -- mailbox inbox
+    # → Bob (1 message)
+    #     [timestamp] Re: Project files
+    #       Got it, thanks!
+    ```
+
+## Data Storage
+
+- **Contacts** are stored in `./data/contacts/` (localStorage polyfill)
+- **Messages** are stored on the Swarm network (encrypted)
+- **Notifications** are on Gnosis Chain (ECIES-encrypted events)
+
+To reset contacts: `rm -rf ./data/contacts/`
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PRIVATE_KEY` | Yes | — | secp256k1 private key (hex, 0x-prefixed) |
+| `BEE_URL` | No | `http://localhost:1633` | Bee node API URL |
+| `STAMP` | For writes | — | Postage stamp batch ID |
+| `GNOSIS_RPC_URL` | No | `https://rpc.gnosischain.com` | Gnosis Chain RPC endpoint |
+| `CONTRACT_ADDRESS` | No | `0x318aE1...` | SwarmNotificationRegistry address |

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,107 @@
 
 A CLI tool that exercises every module in the library. Used for manual testing, demos, and as an integration example.
 
+## How It Works
+
+The flow diagram below shows the full lifecycle of a first-contact notification and subsequent messaging between two users (Alice and Bob). Each step maps to a CLI command.
+
+```
+ ALICE                                                              BOB
+ ─────                                                              ───
+
+ 1. PUBLISH IDENTITY                                    1. PUBLISH IDENTITY
+ ┌────────────────────┐                                ┌────────────────────┐
+ │ identity publish   │                                │ identity publish   │
+ │                    │                                │                    │
+ │ Writes to Swarm    │                                │ Writes to Swarm    │
+ │ feed at topic:     │                                │ feed at topic:     │
+ │ keccak256(         │                                │ keccak256(         │
+ │  "swarm-identity-" │                                │  "swarm-identity-" │
+ │  + ethAddress)     │                                │  + ethAddress)     │
+ └────────────────────┘                                └────────────────────┘
+          │                                                      │
+          ▼                                                      ▼
+ 2. DISCOVER + ADD CONTACT                             2. DISCOVER + ADD CONTACT
+ ┌────────────────────┐    read Bob's identity feed    ┌────────────────────┐
+ │ identity resolve   │◄──────────── Swarm ──────────►│ identity resolve   │
+ │ contacts add       │                                │ contacts add       │
+ └────────────────────┘                                └────────────────────┘
+          │                                                      │
+          ▼                                                      │
+ 3. SEND MESSAGE                                                 │
+ ┌────────────────────┐                                          │
+ │ mailbox send       │                                          │
+ │                    │                                          │
+ │ ECDH shared secret │                                          │
+ │ → AES-256-GCM      │                                          │
+ │ → upload to Swarm  │                                          │
+ │ → update feed      │                                          │
+ └────────────────────┘                                          │
+          │                                                      │
+          ▼                                                      │
+ 4. FIRST-CONTACT NOTIFICATION (on-chain)                        │
+ ┌────────────────────┐                                          │
+ │ registry notify    │                                          │
+ │                    │    Gnosis Chain tx:                       │
+ │ ECIES-encrypt      │    notify(keccak256(bobAddr),            │
+ │ {sender, overlay,  │──────── encryptedPayload) ──────────►   │
+ │  feedTopic}        │                                          │
+ │ with Bob's pubkey  │                                          │
+ └────────────────────┘                                          │
+                                                                 ▼
+                                                        5. POLL NOTIFICATIONS
+                                                       ┌────────────────────┐
+                                                       │ registry poll      │
+                                                       │                    │
+                                                       │ eth_getLogs →      │
+                                                       │ ECIES-decrypt →    │
+                                                       │ discover Alice's   │
+                                                       │ {sender, overlay,  │
+                                                       │  feedTopic}        │
+                                                       └────────────────────┘
+                                                                 │
+                                                                 ▼
+                                                        6. READ MESSAGES
+                                                       ┌────────────────────┐
+                                                       │ mailbox read       │
+                                                       │                    │
+                                                       │ Read Alice's feed →│
+                                                       │ ECDH shared secret │
+                                                       │ → AES-GCM decrypt  │
+                                                       │ → "Project files"  │
+                                                       └────────────────────┘
+                                                                 │
+                                                                 ▼
+                                                        7. REPLY
+                                                       ┌────────────────────┐
+                                                       │ mailbox send       │
+                                                       │                    │
+ 8. CHECK INBOX                                        │ Encrypt + upload   │
+ ┌────────────────────┐                                │ to Bob→Alice feed  │
+ │ mailbox inbox      │◄───────── Swarm ──────────────│                    │
+ │                    │                                └────────────────────┘
+ │ "Re: Project files"│
+ │ "Got it, thanks!"  │
+ └────────────────────┘
+```
+
+### Encryption Summary
+
+| Layer | Method | When |
+|-------|--------|------|
+| Messages (mailbox) | **ECDH + AES-256-GCM** — symmetric, both parties derive same key | Between known contacts |
+| Notifications (registry) | **ECIES** — asymmetric, encrypt with recipient's public key | First contact only |
+| Identity feeds | Plaintext JSON on Swarm | Public by design |
+
+### What's On-Chain vs Off-Chain
+
+| Data | Where | Cost |
+|------|-------|------|
+| Identity (public keys, overlay) | **Swarm** feeds | Postage stamp |
+| Messages (encrypted) | **Swarm** feeds | Postage stamp |
+| Contacts | **Local** storage | Free |
+| First-contact notifications | **Gnosis Chain** events | ~22k gas (~0.00002 xDAI) |
+
 ## Prerequisites
 
 - Node.js 18+

--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+/**
+ * Swarm Notify CLI — reference app for testing and demos.
+ *
+ * Usage: npx ts-node examples/cli.ts <command> [options]
+ * Or:    npm run cli -- <command> [options]
+ */
+
+// localStorage polyfill — must be set before importing contacts module
+import { LocalStorage } from 'node-localstorage'
+const store = new LocalStorage('./data/contacts')
+;(globalThis as any).localStorage = store
+
+import 'dotenv/config'
+import { Command } from 'commander'
+import { Bee } from '@ethersphere/bee-js'
+import * as secp from '@noble/secp256k1'
+import { bytesToHex } from '@noble/hashes/utils'
+import { keccak_256 } from '@noble/hashes/sha3'
+
+import * as identity from '../src/identity'
+import * as mailbox from '../src/mailbox'
+import * as contacts from '../src/contacts'
+import * as registry from '../src/registry'
+import { createReadOnlyProvider, createSigningProvider } from './provider'
+
+// ─── Config ─────────────────────────────────────────────────────
+
+const BEE_URL = process.env.BEE_URL || 'http://localhost:1633'
+const STAMP = process.env.STAMP || ''
+const GNOSIS_RPC_URL = process.env.GNOSIS_RPC_URL || 'https://rpc.gnosischain.com'
+const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS || '0x318aE190B77bA39fbcdFA4e84BB7CFD16b846Fcf'
+
+function getPrivateKey(): Uint8Array {
+  const hex = process.env.PRIVATE_KEY
+  if (!hex) {
+    console.error('Error: PRIVATE_KEY env var is required. Set it in .env or export it.')
+    process.exit(1)
+  }
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.substring(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+function getPublicKeyHex(privateKey: Uint8Array): string {
+  return bytesToHex(secp.getPublicKey(privateKey, true))
+}
+
+function getEthAddress(privateKey: Uint8Array): string {
+  const pubKey = secp.getPublicKey(privateKey, false) // uncompressed
+  const hash = keccak_256(pubKey.slice(1)) // remove 0x04 prefix
+  return '0x' + bytesToHex(hash.slice(12)) // last 20 bytes
+}
+
+function requireStamp(): string {
+  if (!STAMP) {
+    console.error('Error: STAMP env var is required for write operations.')
+    process.exit(1)
+  }
+  return STAMP
+}
+
+// ─── CLI ────────────────────────────────────────────────────────
+
+const program = new Command()
+program
+  .name('swarm-notify')
+  .description('CLI reference app for the Swarm Notify library')
+  .version('0.1.0')
+
+// ─── Identity ───────────────────────────────────────────────────
+
+const identityCmd = program.command('identity').description('Identity feed operations')
+
+identityCmd
+  .command('publish')
+  .description('Publish your identity to a Swarm feed')
+  .option('--overlay <hex>', 'Override overlay address (default: fetched from Bee node)')
+  .action(async (opts) => {
+    const privKey = getPrivateKey()
+    const stamp = requireStamp()
+    const bee = new Bee(BEE_URL)
+
+    let overlay = opts.overlay
+    if (!overlay) {
+      try {
+        const addresses = await bee.getNodeAddresses()
+        overlay = String(addresses.overlay)
+      } catch (e) {
+        console.error('Could not fetch overlay from Bee node. Pass --overlay or check BEE_URL.')
+        process.exit(1)
+      }
+    }
+
+    const ethAddress = getEthAddress(privKey)
+    const pubKeyHex = getPublicKeyHex(privKey)
+
+    // Use ethAddress as signer for the feed
+    await identity.publish(bee, ethAddress, stamp, {
+      walletPublicKey: pubKeyHex,
+      beePublicKey: pubKeyHex, // Using wallet key as bee key for CLI simplicity
+      overlay,
+      ethAddress,
+    })
+
+    console.log(`Identity published for ${ethAddress}`)
+    console.log(`  walletPublicKey: ${pubKeyHex}`)
+    console.log(`  overlay: ${overlay}`)
+  })
+
+identityCmd
+  .command('resolve')
+  .description('Resolve an identity by ETH address')
+  .argument('<ethAddress>', 'ETH address to look up')
+  .action(async (ethAddress: string) => {
+    const bee = new Bee(BEE_URL)
+    const result = await identity.resolve(bee, ethAddress)
+
+    if (!result) {
+      console.log(`No identity found for ${ethAddress}`)
+      return
+    }
+
+    console.log(`Identity for ${ethAddress}:`)
+    console.log(JSON.stringify(result, null, 2))
+  })
+
+// ─── Contacts ───────────────────────────────────────────────────
+
+const contactsCmd = program.command('contacts').description('Contact management')
+
+contactsCmd
+  .command('add')
+  .description('Add a contact (resolves identity from Swarm)')
+  .argument('<ethAddress>', 'ETH address')
+  .argument('<nickname>', 'Display name')
+  .option('--wallet-pub <hex>', 'Manually provide wallet public key (skip identity resolve)')
+  .option('--bee-pub <hex>', 'Manually provide bee public key')
+  .option('--overlay <hex>', 'Manually provide overlay address')
+  .action(async (ethAddress: string, nickname: string, opts) => {
+    let swarmId
+
+    if (opts.walletPub && opts.overlay) {
+      // Manual mode — no Bee node needed
+      swarmId = {
+        walletPublicKey: opts.walletPub,
+        beePublicKey: opts.beePub || opts.walletPub,
+        overlay: opts.overlay,
+      }
+    } else {
+      // Resolve from Swarm
+      const bee = new Bee(BEE_URL)
+      const resolved = await identity.resolve(bee, ethAddress)
+      if (!resolved) {
+        console.error(`No identity found for ${ethAddress}. Use --wallet-pub and --overlay to add manually.`)
+        process.exit(1)
+      }
+      swarmId = resolved
+    }
+
+    const contact = contacts.add(ethAddress, nickname, swarmId)
+    console.log(`Contact added: ${contact.nickname} (${contact.ethAddress})`)
+  })
+
+contactsCmd
+  .command('remove')
+  .description('Remove a contact')
+  .argument('<ethAddress>', 'ETH address')
+  .action((ethAddress: string) => {
+    contacts.remove(ethAddress)
+    console.log(`Contact removed: ${ethAddress}`)
+  })
+
+contactsCmd
+  .command('list')
+  .description('List all contacts')
+  .action(() => {
+    const all = contacts.list()
+    if (all.length === 0) {
+      console.log('No contacts.')
+      return
+    }
+    for (const c of all) {
+      console.log(`  ${c.nickname} — ${c.ethAddress} (overlay: ${c.overlay.slice(0, 16)}...)`)
+    }
+  })
+
+// ─── Mailbox ────────────────────────────────────────────────────
+
+const mailboxCmd = program.command('mailbox').description('Send and receive messages')
+
+mailboxCmd
+  .command('send')
+  .description('Send an encrypted message to a contact')
+  .argument('<ethAddress>', 'Recipient ETH address (must be in contacts)')
+  .requiredOption('-s, --subject <text>', 'Message subject')
+  .requiredOption('-b, --body <text>', 'Message body')
+  .action(async (ethAddress: string, opts) => {
+    const privKey = getPrivateKey()
+    const stamp = requireStamp()
+    const bee = new Bee(BEE_URL)
+
+    const myAddress = getEthAddress(privKey)
+    let myOverlay: string
+    try {
+      const addresses = await bee.getNodeAddresses()
+      myOverlay = String(addresses.overlay)
+    } catch {
+      console.error('Could not fetch overlay from Bee node. Check BEE_URL.')
+      process.exit(1)
+    }
+
+    const contact = contacts.list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
+    if (!contact) {
+      console.error(`Contact not found: ${ethAddress}. Add them first with 'contacts add'.`)
+      process.exit(1)
+    }
+
+    await mailbox.send(bee, myAddress, stamp, privKey, myOverlay, contact, {
+      subject: opts.subject,
+      body: opts.body,
+    })
+
+    console.log(`Message sent to ${contact.nickname} (${contact.ethAddress})`)
+  })
+
+mailboxCmd
+  .command('read')
+  .description('Read messages from a specific contact')
+  .argument('<ethAddress>', 'Contact ETH address')
+  .action(async (ethAddress: string) => {
+    const privKey = getPrivateKey()
+    const bee = new Bee(BEE_URL)
+
+    let myOverlay: string
+    try {
+      const addresses = await bee.getNodeAddresses()
+      myOverlay = String(addresses.overlay)
+    } catch {
+      console.error('Could not fetch overlay from Bee node. Check BEE_URL.')
+      process.exit(1)
+    }
+
+    const contact = contacts.list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
+    if (!contact) {
+      console.error(`Contact not found: ${ethAddress}`)
+      process.exit(1)
+    }
+
+    const messages = await mailbox.readMessages(bee, privKey, myOverlay, contact)
+
+    if (messages.length === 0) {
+      console.log(`No messages from ${contact.nickname}.`)
+      return
+    }
+
+    for (const msg of messages) {
+      const date = new Date(msg.ts).toLocaleString()
+      console.log(`\n[${date}] ${msg.subject}`)
+      console.log(`  ${msg.body}`)
+    }
+  })
+
+mailboxCmd
+  .command('inbox')
+  .description('Check inbox across all contacts')
+  .action(async () => {
+    const privKey = getPrivateKey()
+    const bee = new Bee(BEE_URL)
+
+    let myOverlay: string
+    try {
+      const addresses = await bee.getNodeAddresses()
+      myOverlay = String(addresses.overlay)
+    } catch {
+      console.error('Could not fetch overlay from Bee node. Check BEE_URL.')
+      process.exit(1)
+    }
+
+    const allContacts = contacts.list()
+    if (allContacts.length === 0) {
+      console.log('No contacts. Add some first.')
+      return
+    }
+
+    const inbox = await mailbox.checkInbox(bee, privKey, myOverlay, allContacts)
+
+    if (inbox.length === 0) {
+      console.log('No new messages.')
+      return
+    }
+
+    for (const { contact, messages } of inbox) {
+      console.log(`\n── ${contact.nickname} (${messages.length} message${messages.length > 1 ? 's' : ''}) ──`)
+      for (const msg of messages) {
+        const date = new Date(msg.ts).toLocaleString()
+        console.log(`  [${date}] ${msg.subject}`)
+        console.log(`    ${msg.body}`)
+      }
+    }
+  })
+
+// ─── Registry ───────────────────────────────────────────────────
+
+const registryCmd = program.command('registry').description('On-chain notification registry')
+
+registryCmd
+  .command('notify')
+  .description('Send a first-contact notification (on-chain)')
+  .argument('<ethAddress>', 'Recipient ETH address (must be in contacts)')
+  .action(async (ethAddress: string) => {
+    const privKey = getPrivateKey()
+    const provider = createSigningProvider(GNOSIS_RPC_URL, '0x' + bytesToHex(privKey))
+
+    let myOverlay: string
+    try {
+      const bee = new Bee(BEE_URL)
+      const addresses = await bee.getNodeAddresses()
+      myOverlay = String(addresses.overlay)
+    } catch {
+      console.error('Could not fetch overlay from Bee node. Check BEE_URL.')
+      process.exit(1)
+    }
+
+    const contact = contacts.list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
+    if (!contact) {
+      console.error(`Contact not found: ${ethAddress}. Add them first.`)
+      process.exit(1)
+    }
+
+    const myAddress = getEthAddress(privKey)
+    const feedTopic = mailbox.feedTopic(myOverlay, contact.overlay)
+    const recipientPubKey = hexToBytes(contact.walletPublicKey)
+
+    const txHash = await registry.sendNotification(
+      provider,
+      CONTRACT_ADDRESS,
+      recipientPubKey,
+      contact.ethAddress,
+      { sender: myAddress, overlay: myOverlay, feedTopic },
+      privKey,
+    )
+
+    console.log(`Notification sent to ${contact.nickname}`)
+    console.log(`  tx: ${txHash}`)
+  })
+
+registryCmd
+  .command('poll')
+  .description('Poll for new notifications')
+  .option('--from-block <n>', 'Start block (default: 0)', '0')
+  .action(async (opts) => {
+    const privKey = getPrivateKey()
+    const myAddress = getEthAddress(privKey)
+    const provider = createReadOnlyProvider(GNOSIS_RPC_URL)
+    const fromBlock = parseInt(opts.fromBlock)
+
+    console.log(`Polling notifications for ${myAddress} from block ${fromBlock}...`)
+
+    const notifications = await registry.pollNotifications(provider, CONTRACT_ADDRESS, myAddress, privKey, fromBlock)
+
+    if (notifications.length === 0) {
+      console.log('No notifications found.')
+      return
+    }
+
+    console.log(`Found ${notifications.length} notification(s):`)
+    for (const n of notifications) {
+      console.log(`\n  Block ${n.blockNumber}:`)
+      console.log(`    sender:    ${n.payload.sender}`)
+      console.log(`    overlay:   ${n.payload.overlay}`)
+      console.log(`    feedTopic: ${n.payload.feedTopic}`)
+    }
+  })
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(h.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(h.substring(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+// ─── Run ────────────────────────────────────────────────────────
+
+program.parse()

--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -73,11 +73,11 @@ program
 
 // ─── Identity ───────────────────────────────────────────────────
 
-const identityCmd = program.command('identity').description('Identity feed operations')
+const identityCmd = program.command('identity').description('Publish and resolve identity feeds on Swarm (Layer 1)')
 
 identityCmd
   .command('publish')
-  .description('Publish your identity to a Swarm feed')
+  .description('Publish your identity (public keys + overlay) to a Swarm feed. One-time setup — others can then discover you by ETH address.')
   .option('--overlay <hex>', 'Override overlay address (default: fetched from Bee node)')
   .action(async (opts) => {
     const privKey = getPrivateKey()
@@ -113,7 +113,7 @@ identityCmd
 
 identityCmd
   .command('resolve')
-  .description('Resolve an identity by ETH address')
+  .description('Look up someone\'s identity (public keys + overlay) from their Swarm feed')
   .argument('<ethAddress>', 'ETH address to look up')
   .action(async (ethAddress: string) => {
     const bee = new Bee(BEE_URL)
@@ -130,11 +130,11 @@ identityCmd
 
 // ─── Contacts ───────────────────────────────────────────────────
 
-const contactsCmd = program.command('contacts').description('Contact management')
+const contactsCmd = program.command('contacts').description('Manage local address book (stored in ./data/contacts/)')
 
 contactsCmd
   .command('add')
-  .description('Add a contact (resolves identity from Swarm)')
+  .description('Add a contact — resolves their identity from Swarm, or pass keys manually with --wallet-pub and --overlay')
   .argument('<ethAddress>', 'ETH address')
   .argument('<nickname>', 'Display name')
   .option('--wallet-pub <hex>', 'Manually provide wallet public key (skip identity resolve)')
@@ -190,11 +190,11 @@ contactsCmd
 
 // ─── Mailbox ────────────────────────────────────────────────────
 
-const mailboxCmd = program.command('mailbox').description('Send and receive messages')
+const mailboxCmd = program.command('mailbox').description('Send and receive E2E encrypted messages via Swarm feeds (Layer 2)')
 
 mailboxCmd
   .command('send')
-  .description('Send an encrypted message to a contact')
+  .description('Send an ECDH+AES-256-GCM encrypted message to a contact via their Swarm mailbox feed')
   .argument('<ethAddress>', 'Recipient ETH address (must be in contacts)')
   .requiredOption('-s, --subject <text>', 'Message subject')
   .requiredOption('-b, --body <text>', 'Message body')
@@ -305,11 +305,11 @@ mailboxCmd
 
 // ─── Registry ───────────────────────────────────────────────────
 
-const registryCmd = program.command('registry').description('On-chain notification registry')
+const registryCmd = program.command('registry').description('On-chain notification registry on Gnosis Chain (Layer 3) — for first-contact discovery')
 
 registryCmd
   .command('notify')
-  .description('Send a first-contact notification (on-chain)')
+  .description('Send ECIES-encrypted first-contact notification on Gnosis Chain (~22k gas). Only needed once per new contact.')
   .argument('<ethAddress>', 'Recipient ETH address (must be in contacts)')
   .action(async (ethAddress: string) => {
     const privKey = getPrivateKey()
@@ -350,7 +350,7 @@ registryCmd
 
 registryCmd
   .command('poll')
-  .description('Poll for new notifications')
+  .description('Poll Gnosis Chain for incoming notifications — discovers new contacts who messaged you')
   .option('--from-block <n>', 'Start block (default: 0)', '0')
   .action(async (opts) => {
     const privKey = getPrivateKey()

--- a/examples/provider.ts
+++ b/examples/provider.ts
@@ -1,0 +1,85 @@
+/**
+ * NotifyProvider implementations for the CLI.
+ *
+ * - createReadOnlyProvider: raw fetch JSON-RPC (zero deps beyond Node 18+ fetch)
+ * - createSigningProvider: ethers-based for transaction signing (devDependency)
+ */
+
+import type { NotifyProvider } from '../src/types'
+
+/** JSON-RPC helper — makes a raw fetch call to an Ethereum JSON-RPC endpoint. */
+async function rpcCall(rpcUrl: string, method: string, params: unknown[]): Promise<unknown> {
+  const res = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  })
+  const json = (await res.json()) as { result?: unknown; error?: { message: string } }
+  if (json.error) throw new Error(`RPC error: ${json.error.message}`)
+  return json.result
+}
+
+/**
+ * Create a read-only NotifyProvider using raw fetch (no ethers dependency).
+ * Supports getLogs and call. sendTransaction throws — use createSigningProvider for writes.
+ */
+export function createReadOnlyProvider(rpcUrl: string): NotifyProvider {
+  return {
+    async getLogs(filter) {
+      const params = [
+        {
+          address: filter.address,
+          topics: filter.topics,
+          fromBlock: '0x' + filter.fromBlock.toString(16),
+          toBlock: filter.toBlock === 'latest' || !filter.toBlock ? 'latest' : '0x' + filter.toBlock.toString(16),
+        },
+      ]
+      const result = (await rpcCall(rpcUrl, 'eth_getLogs', params)) as {
+        data: string
+        blockNumber: string
+      }[]
+      return result.map((log) => ({
+        data: log.data,
+        blockNumber: parseInt(log.blockNumber, 16),
+      }))
+    },
+
+    async call(tx) {
+      return (await rpcCall(rpcUrl, 'eth_call', [tx, 'latest'])) as string
+    },
+
+    async sendTransaction() {
+      throw new Error(
+        'Read-only provider cannot send transactions. Use createSigningProvider() for write operations.',
+      )
+    },
+  }
+}
+
+/**
+ * Create a signing NotifyProvider using ethers (devDependency).
+ * Supports all operations including sendTransaction.
+ */
+export function createSigningProvider(rpcUrl: string, privateKey: string): NotifyProvider {
+  // Dynamic import — ethers is a devDependency, not in the library's runtime bundle
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { JsonRpcProvider, Wallet } = require('ethers') as typeof import('ethers')
+  const provider = new JsonRpcProvider(rpcUrl)
+  const wallet = new Wallet(privateKey, provider)
+
+  const readOnly = createReadOnlyProvider(rpcUrl)
+
+  return {
+    getLogs: readOnly.getLogs,
+    call: readOnly.call,
+
+    async sendTransaction(tx) {
+      const response = await wallet.sendTransaction({
+        to: tx.to,
+        data: tx.data,
+        value: tx.value || '0x0',
+      })
+      return response.hash
+    },
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,14 @@
         "@ethersphere/bee-js": "^11.1.1",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
         "@types/node": "^22.15.3",
+        "@types/node-localstorage": "^1.3.3",
+        "commander": "^14.0.3",
         "dotenv": "^17.4.2",
         "eslint": "^9.25.1",
         "ethers": "^6.16.0",
         "hardhat": "^2.28.6",
         "jsdom": "^29.0.2",
+        "node-localstorage": "^3.0.5",
         "prettier": "^3.5.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
@@ -2391,6 +2394,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-localstorage": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node-localstorage/-/node-localstorage-1.3.3.tgz",
+      "integrity": "sha512-Wkn5g4eM5x10UNV9Xvl9K6y6m0zorocuJy4WjB5muUdyMZuPbZpSJG3hlhjGHe1HGxbOQO7RcB+jlHcNwkh+Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -3060,13 +3073,13 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 12"
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {
@@ -5098,6 +5111,19 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/node-localstorage": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-3.0.5.tgz",
+      "integrity": "sha512-GCwtK33iwVXboZWYcqQHu3aRvXEBwmPkAMRBLeaX86ufhqslyUkLGsi4aW3INEfdQYpUB5M9qtYf3eHvAk2VBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5607,6 +5633,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/solc": {
       "version": "0.8.26",
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.26.tgz",
@@ -5627,6 +5666,16 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/solc/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/solc/node_modules/semver": {
@@ -6432,6 +6481,20 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/ws": {
       "version": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint:check": "eslint src/ test/ && prettier --check src/ test/",
     "check:types": "tsc --noEmit",
     "compile:contracts": "hardhat compile",
-    "deploy": "hardhat run scripts/deploy.ts"
+    "deploy": "hardhat run scripts/deploy.ts",
+    "cli": "ts-node examples/cli.ts"
   },
   "peerDependencies": {
     "@ethersphere/bee-js": ">=7.0.0"
@@ -28,11 +29,14 @@
     "@ethersphere/bee-js": "^11.1.1",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",
     "@types/node": "^22.15.3",
+    "@types/node-localstorage": "^1.3.3",
+    "commander": "^14.0.3",
     "dotenv": "^17.4.2",
     "eslint": "^9.25.1",
     "ethers": "^6.16.0",
     "hardhat": "^2.28.6",
     "jsdom": "^29.0.2",
+    "node-localstorage": "^3.0.5",
     "prettier": "^3.5.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check:types": "tsc --noEmit",
     "compile:contracts": "hardhat compile",
     "deploy": "hardhat run scripts/deploy.ts",
-    "cli": "ts-node examples/cli.ts"
+    "cli": "ts-node examples/cli.ts",
+    "test:e2e": "vitest run test/e2e.test.ts --config vitest.e2e.config.ts"
   },
   "peerDependencies": {
     "@ethersphere/bee-js": ">=7.0.0"

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1,0 +1,359 @@
+/**
+ * End-to-end tests against real infrastructure.
+ *
+ * Requires:
+ * - Bee node running on BEE_URL (default http://localhost:1633) with a usable stamp
+ * - Gnosis Chain RPC access
+ * - Funded deployer wallet (DEPLOYER_PRIVATE_KEY in .env)
+ *
+ * Run with: npm run test:e2e
+ * NOT included in default `npm test` — these are slow, cost gas, and need live services.
+ */
+import 'dotenv/config'
+import { describe, it, expect, beforeAll } from 'vitest'
+import { Bee } from '@ethersphere/bee-js'
+import * as secp from '@noble/secp256k1'
+import { bytesToHex } from '@noble/hashes/utils'
+import { keccak_256 } from '@noble/hashes/sha3'
+
+import * as identity from '../src/identity'
+import * as mailbox from '../src/mailbox'
+import * as registry from '../src/registry'
+import type { NotifyProvider, NotificationPayload } from '../src/types'
+
+// ─── Config from environment ────────────────────────────────────
+
+const BEE_URL = process.env.BEE_URL || 'http://localhost:1633'
+const GNOSIS_RPC_URL = process.env.GNOSIS_RPC_URL || 'https://rpc.gnosischain.com'
+const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS || '0x318aE190B77bA39fbcdFA4e84BB7CFD16b846Fcf'
+const PRIVATE_KEY_HEX = process.env.DEPLOYER_PRIVATE_KEY || ''
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(h.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(h.substring(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+function getEthAddress(privateKey: Uint8Array): string {
+  const pubKey = secp.getPublicKey(privateKey, false)
+  const hash = keccak_256(pubKey.slice(1))
+  return '0x' + bytesToHex(hash.slice(12))
+}
+
+/** Create a signing NotifyProvider using ethers. */
+function createSigningProvider(rpcUrl: string, privateKey: string): NotifyProvider {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { JsonRpcProvider, Wallet } = require('ethers') as typeof import('ethers')
+  const provider = new JsonRpcProvider(rpcUrl)
+  const wallet = new Wallet(privateKey, provider)
+
+  return {
+    async getLogs(filter) {
+      const result = await provider.getLogs({
+        address: filter.address,
+        topics: filter.topics,
+        fromBlock: filter.fromBlock,
+        toBlock: filter.toBlock === 'latest' ? 'latest' : filter.toBlock,
+      })
+      return result.map((log) => ({
+        data: log.data,
+        blockNumber: log.blockNumber,
+      }))
+    },
+    async call(tx) {
+      return await provider.call(tx)
+    },
+    async sendTransaction(tx) {
+      const response = await wallet.sendTransaction({
+        to: tx.to,
+        data: tx.data,
+        value: tx.value || '0x0',
+      })
+      return response.hash
+    },
+  }
+}
+
+// ─── Test state ─────────────────────────────────────────────────
+
+let bee: Bee
+let stamp: string
+let privateKey: Uint8Array
+let ethAddress: string
+let publicKeyHex: string
+let overlay: string
+
+// Two test identities — Alice (from DEPLOYER_PRIVATE_KEY) and Bob (generated)
+let bobPrivateKey: Uint8Array
+let bobPublicKeyHex: string
+let bobEthAddress: string
+let bobOverlay: string
+
+beforeAll(async () => {
+  // Validate environment
+  if (!PRIVATE_KEY_HEX) {
+    throw new Error('DEPLOYER_PRIVATE_KEY not set in .env — needed for E2E tests')
+  }
+
+  bee = new Bee(BEE_URL)
+
+  // Check Bee health
+  const health = await bee.isConnected()
+  if (!health) {
+    throw new Error(`Bee node not reachable at ${BEE_URL}`)
+  }
+
+  // Get a usable stamp
+  const stamps = await bee.getAllPostageBatch()
+  const usable = stamps.find((s) => s.usable)
+  if (!usable) {
+    throw new Error('No usable postage stamp on Bee node')
+  }
+  stamp = String(usable.batchID)
+
+  // Alice's keys (from .env)
+  privateKey = hexToBytes(PRIVATE_KEY_HEX)
+  ethAddress = getEthAddress(privateKey)
+  publicKeyHex = bytesToHex(secp.getPublicKey(privateKey, true))
+
+  // Get overlay from Bee node
+  const addresses = await bee.getNodeAddresses()
+  overlay = String(addresses.overlay)
+
+  // Bob's keys (generated)
+  bobPrivateKey = secp.utils.randomPrivateKey()
+  bobPublicKeyHex = bytesToHex(secp.getPublicKey(bobPrivateKey, true))
+  bobEthAddress = getEthAddress(bobPrivateKey)
+  bobOverlay = bytesToHex(keccak_256(secp.getPublicKey(bobPrivateKey, true))).slice(0, 32)
+
+  console.log('E2E test config:')
+  console.log(`  Bee:      ${BEE_URL}`)
+  console.log(`  Stamp:    ${stamp.slice(0, 16)}...`)
+  console.log(`  Alice:    ${ethAddress}`)
+  console.log(`  Bob:      ${bobEthAddress}`)
+  console.log(`  Contract: ${CONTRACT_ADDRESS}`)
+}, 30000)
+
+// ─── Identity tests (Bee node) ──────────────────────────────────
+
+describe('identity: real Bee node', () => {
+  it('publishes and resolves identity', async () => {
+    const swarmIdentity = {
+      walletPublicKey: publicKeyHex,
+      beePublicKey: publicKeyHex,
+      overlay,
+      ethAddress,
+    }
+
+    // Publish Alice's identity (signer = private key, not ETH address)
+    await identity.publish(bee, PRIVATE_KEY_HEX, stamp, swarmIdentity)
+
+    // Resolve it back
+    const resolved = await identity.resolve(bee, ethAddress)
+
+    expect(resolved).not.toBeNull()
+    expect(resolved!.walletPublicKey).toBe(publicKeyHex)
+    expect(resolved!.overlay).toBe(overlay)
+  }, 30000)
+
+  it('returns null for non-existent identity', async () => {
+    const fakeAddress = '0x' + '00'.repeat(20)
+    const resolved = await identity.resolve(bee, fakeAddress)
+    expect(resolved).toBeNull()
+  }, 10000)
+})
+
+// ─── Mailbox tests (Bee node) ───────────────────────────────────
+
+describe('mailbox: real Bee node', () => {
+  it('sends a message and reads it back', async () => {
+    // Create a contact for Bob (using generated keys)
+    const bobContact = {
+      ethAddress: bobEthAddress.toLowerCase(),
+      nickname: 'Bob',
+      walletPublicKey: bobPublicKeyHex,
+      beePublicKey: bobPublicKeyHex,
+      overlay: bobOverlay,
+      addedAt: Date.now(),
+    }
+
+    // Alice sends a message to Bob (signer = private key hex)
+    const testSubject = `E2E test ${Date.now()}`
+    await mailbox.send(bee, PRIVATE_KEY_HEX, stamp, privateKey, overlay, bobContact, {
+      subject: testSubject,
+      body: 'End-to-end test message via real Bee node',
+    })
+
+    // Bob reads messages from Alice
+    const aliceContact = {
+      ethAddress: ethAddress.toLowerCase(),
+      nickname: 'Alice',
+      walletPublicKey: publicKeyHex,
+      beePublicKey: publicKeyHex,
+      overlay,
+      addedAt: Date.now(),
+    }
+    const messages = await mailbox.readMessages(bee, bobPrivateKey, bobOverlay, aliceContact)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].subject).toBe(testSubject)
+    expect(messages[0].body).toBe('End-to-end test message via real Bee node')
+    expect(messages[0].v).toBe(1)
+  }, 60000)
+})
+
+// ─── Registry tests (Gnosis Chain) ─────────────────────────────
+
+describe('registry: real Gnosis Chain', () => {
+  let notificationBlockNumber: number
+
+  it('sends an on-chain notification', async () => {
+    const provider = createSigningProvider(GNOSIS_RPC_URL, PRIVATE_KEY_HEX)
+
+    const payload: NotificationPayload = {
+      sender: ethAddress,
+      overlay,
+      feedTopic: mailbox.feedTopic(overlay, bobOverlay),
+    }
+
+    const txHash = await registry.sendNotification(
+      provider,
+      CONTRACT_ADDRESS,
+      secp.getPublicKey(bobPrivateKey, true),
+      bobEthAddress,
+      payload,
+      privateKey,
+    )
+
+    expect(txHash).toMatch(/^0x[0-9a-fA-F]{64}$/)
+    console.log(`  Notification tx: ${txHash}`)
+
+    // Wait for tx to be mined
+    const { JsonRpcProvider } = require('ethers') as typeof import('ethers')
+    const ethProvider = new JsonRpcProvider(GNOSIS_RPC_URL)
+    const receipt = await ethProvider.waitForTransaction(txHash, 1, 30000)
+    expect(receipt).not.toBeNull()
+    notificationBlockNumber = receipt!.blockNumber
+    console.log(`  Mined in block: ${notificationBlockNumber}`)
+  }, 60000)
+
+  it('polls and discovers the notification', async () => {
+    const provider = createSigningProvider(GNOSIS_RPC_URL, PRIVATE_KEY_HEX)
+
+    // Bob polls from the block before the notification
+    const fromBlock = notificationBlockNumber > 0 ? notificationBlockNumber - 1 : 0
+    const notifications = await registry.pollNotifications(
+      provider,
+      CONTRACT_ADDRESS,
+      bobEthAddress,
+      bobPrivateKey,
+      fromBlock,
+    )
+
+    expect(notifications.length).toBeGreaterThanOrEqual(1)
+
+    // Find our notification
+    const ours = notifications.find((n) => n.payload.sender === ethAddress)
+    expect(ours).toBeDefined()
+    expect(ours!.payload.overlay).toBe(overlay)
+    expect(ours!.payload.feedTopic).toBe(mailbox.feedTopic(overlay, bobOverlay))
+    expect(ours!.blockNumber).toBe(notificationBlockNumber)
+  }, 30000)
+})
+
+// ─── Full flow (Bee + Gnosis Chain) ─────────────────────────────
+
+describe('full E2E flow: identity → message → notification → discovery', () => {
+  it('Alice publishes, sends message, notifies — Bob discovers and reads', async () => {
+    const provider = createSigningProvider(GNOSIS_RPC_URL, PRIVATE_KEY_HEX)
+
+    // Generate a fresh "Charlie" to avoid collisions with earlier tests
+    const charliePrivateKey = secp.utils.randomPrivateKey()
+    const charliePublicKeyHex = bytesToHex(secp.getPublicKey(charliePrivateKey, true))
+    const charlieEthAddress = getEthAddress(charliePrivateKey)
+    const charlieOverlay = bytesToHex(keccak_256(secp.getPublicKey(charliePrivateKey, true))).slice(0, 32)
+
+    // 1. Ensure Alice's identity is published
+    await identity.publish(bee, PRIVATE_KEY_HEX, stamp, {
+      walletPublicKey: publicKeyHex,
+      beePublicKey: publicKeyHex,
+      overlay,
+      ethAddress,
+    })
+    const aliceId = await identity.resolve(bee, ethAddress)
+    expect(aliceId).not.toBeNull()
+
+    // 2. Alice sends a message to Charlie
+    const charlieContact = {
+      ethAddress: charlieEthAddress.toLowerCase(),
+      nickname: 'Charlie',
+      walletPublicKey: charliePublicKeyHex,
+      beePublicKey: charliePublicKeyHex,
+      overlay: charlieOverlay,
+      addedAt: Date.now(),
+    }
+
+    const testSubject = `Full flow ${Date.now()}`
+    await mailbox.send(bee, PRIVATE_KEY_HEX, stamp, privateKey, overlay, charlieContact, {
+      subject: testSubject,
+      body: 'Full E2E flow test',
+    })
+
+    // 3. Alice sends on-chain notification to Charlie
+    const feedTopic = mailbox.feedTopic(overlay, charlieOverlay)
+    const txHash = await registry.sendNotification(
+      provider,
+      CONTRACT_ADDRESS,
+      secp.getPublicKey(charliePrivateKey, true),
+      charlieEthAddress,
+      { sender: ethAddress, overlay, feedTopic },
+      privateKey,
+    )
+    console.log(`  Full flow notification tx: ${txHash}`)
+
+    // Wait for mining
+    const { JsonRpcProvider } = require('ethers') as typeof import('ethers')
+    const ethProvider = new JsonRpcProvider(GNOSIS_RPC_URL)
+    const receipt = await ethProvider.waitForTransaction(txHash, 1, 30000)
+
+    // 4. Charlie polls registry — discovers Alice
+    const notifications = await registry.pollNotifications(
+      provider,
+      CONTRACT_ADDRESS,
+      charlieEthAddress,
+      charliePrivateKey,
+      receipt!.blockNumber - 1,
+    )
+
+    expect(notifications.length).toBeGreaterThanOrEqual(1)
+    const discovery = notifications.find((n) => n.payload.sender === ethAddress)
+    expect(discovery).toBeDefined()
+
+    // 5. Charlie resolves Alice's identity from discovered address
+    const discoveredAlice = await identity.resolve(bee, discovery!.payload.sender)
+    expect(discoveredAlice).not.toBeNull()
+    expect(discoveredAlice!.walletPublicKey).toBe(publicKeyHex)
+
+    // 6. Charlie reads messages from Alice
+    const aliceContact = {
+      ethAddress: ethAddress.toLowerCase(),
+      nickname: 'Alice',
+      walletPublicKey: discoveredAlice!.walletPublicKey,
+      beePublicKey: discoveredAlice!.beePublicKey,
+      overlay: discoveredAlice!.overlay,
+      addedAt: Date.now(),
+    }
+    const messages = await mailbox.readMessages(bee, charliePrivateKey, charlieOverlay, aliceContact)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].subject).toBe(testSubject)
+    expect(messages[0].body).toBe('Full E2E flow test')
+
+    console.log('  Full E2E flow passed: identity → message → notification → discovery → read')
+  }, 120000)
+})

--- a/test/helpers/mock-bee.ts
+++ b/test/helpers/mock-bee.ts
@@ -1,0 +1,94 @@
+/**
+ * In-memory Bee mock for integration tests.
+ * Stores blobs and feed pointers in Maps so read-after-write works.
+ */
+
+import { keccak_256 } from '@noble/hashes/sha3'
+import { bytesToHex } from '@noble/hashes/utils'
+
+export class MockBee {
+  /** Blob storage: reference → data */
+  private blobs = new Map<string, Uint8Array>()
+  /** Feed storage: "topic:owner" → payload (Uint8Array) or reference (string) */
+  private feedPayloads = new Map<string, Uint8Array>()
+  private feedReferences = new Map<string, string>()
+
+  /** Upload data blob. Returns a deterministic reference (hash of data). */
+  async uploadData(_stamp: string, data: Uint8Array): Promise<{ reference: { toHex: () => string } }> {
+    const ref = bytesToHex(keccak_256(data))
+    this.blobs.set(ref, new Uint8Array(data))
+    return { reference: { toHex: () => ref } }
+  }
+
+  /** Download a previously uploaded blob by reference. */
+  async downloadData(reference: string): Promise<{ data: Uint8Array }> {
+    const data = this.blobs.get(reference)
+    if (!data) throw new Error(`Blob not found: ${reference}`)
+    return { data: new Uint8Array(data) }
+  }
+
+  /**
+   * Create a feed writer for a topic + signer.
+   * The signer is used as the owner address (simplified for testing).
+   */
+  makeFeedWriter(topic: string, signer: string | Uint8Array) {
+    const ownerHex = typeof signer === 'string'
+      ? signer.replace('0x', '').slice(0, 40)
+      : bytesToHex(signer).slice(0, 40)
+
+    const key = `${topic}:${ownerHex}`
+
+    return {
+      owner: { toHex: () => ownerHex },
+
+      /** Upload raw payload to the feed (used by identity.publish). */
+      uploadPayload: async (_stamp: string, payload: Uint8Array) => {
+        this.feedPayloads.set(key, new Uint8Array(payload))
+        return { reference: 'feed-' + key }
+      },
+
+      /** Upload a reference to the feed (used by mailbox.send). */
+      uploadReference: async (_stamp: string, reference: { toHex?: () => string } | string) => {
+        const ref = typeof reference === 'string' ? reference : reference.toHex!()
+        this.feedReferences.set(key, ref)
+      },
+    }
+  }
+
+  /**
+   * Create a feed reader for a topic + owner address.
+   * Returns the last payload or referenced blob.
+   */
+  makeFeedReader(topic: string, address: string) {
+    const ownerHex = address.replace('0x', '').toLowerCase()
+    const key = `${topic}:${ownerHex}`
+
+    return {
+      downloadPayload: async () => {
+        // First check for direct payload (identity feeds)
+        const directPayload = this.feedPayloads.get(key)
+        if (directPayload) {
+          return { payload: { toUint8Array: () => new Uint8Array(directPayload) } }
+        }
+
+        // Then check for reference-based payload (mailbox feeds)
+        const ref = this.feedReferences.get(key)
+        if (ref) {
+          const data = this.blobs.get(ref)
+          if (data) {
+            return { payload: { toUint8Array: () => new Uint8Array(data) } }
+          }
+        }
+
+        throw new Error(`Feed not found: ${key}`)
+      },
+    }
+  }
+
+  /** Reset all stored data. */
+  clear(): void {
+    this.blobs.clear()
+    this.feedPayloads.clear()
+    this.feedReferences.clear()
+  }
+}

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,0 +1,553 @@
+// @vitest-environment jsdom
+/**
+ * Integration tests — exercise the full library flow end-to-end
+ * with mocked Bee node and NotifyProvider.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import * as secp from '@noble/secp256k1'
+import { bytesToHex } from '@noble/hashes/utils'
+import { keccak_256 } from '@noble/hashes/sha3'
+import { MockBee } from './helpers/mock-bee'
+import * as identity from '../src/identity'
+import * as mailbox from '../src/mailbox'
+import * as contacts from '../src/contacts'
+import * as registry from '../src/registry'
+import { eciesEncrypt } from '../src/crypto'
+import type { NotifyProvider, NotificationPayload } from '../src/types'
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function makeUser() {
+  const privateKey = secp.utils.randomPrivateKey()
+  const publicKey = secp.getPublicKey(privateKey, true)
+  const publicKeyHex = bytesToHex(publicKey)
+  const ethAddress = '0x' + bytesToHex(publicKey.slice(1, 21))
+  const overlay = bytesToHex(keccak_256(publicKey)).slice(0, 32)
+  const beePublicKey = '04' + bytesToHex(secp.utils.randomPrivateKey())
+  return { privateKey, publicKey, publicKeyHex, ethAddress, overlay, beePublicKey }
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(h.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(h.substring(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+/** Pad Uint8Array to multiple of 32 bytes. */
+function padRight32(data: Uint8Array): Uint8Array {
+  const remainder = data.length % 32
+  if (remainder === 0) return data
+  const padded = new Uint8Array(data.length + (32 - remainder))
+  padded.set(data)
+  return padded
+}
+
+/** Encode a uint256 as 32-byte big-endian. */
+function encodeUint256(value: number): Uint8Array {
+  const buf = new Uint8Array(32)
+  let v = value
+  for (let i = 31; i >= 24 && v > 0; i--) {
+    buf[i] = v & 0xff
+    v = Math.floor(v / 256)
+  }
+  return buf
+}
+
+/** Build mock event log data for a bytes parameter. */
+function encodeEventData(payload: Uint8Array): string {
+  const paddedPayload = padRight32(payload)
+  const data = new Uint8Array(32 + 32 + paddedPayload.length)
+  data.set(encodeUint256(32), 0)
+  data.set(encodeUint256(payload.length), 32)
+  data.set(paddedPayload, 64)
+  return (
+    '0x' +
+    Array.from(data)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('')
+  )
+}
+
+/** Create a mock NotifyProvider that stores logs for read-after-write. */
+function createMockProvider() {
+  const logs: { data: string; blockNumber: number; topics: string[] }[] = []
+  let blockNumber = 0
+
+  const provider: NotifyProvider & {
+    logs: typeof logs
+    sentTxs: { to: string; data: string }[]
+  } = {
+    logs,
+    sentTxs: [],
+
+    getLogs: vi.fn(async (filter) => {
+      return logs
+        .filter(
+          (log) =>
+            log.blockNumber >= filter.fromBlock &&
+            (!filter.topics[1] || log.topics[1] === filter.topics[1]),
+        )
+        .map((log) => ({ data: log.data, blockNumber: log.blockNumber }))
+    }),
+
+    call: vi.fn(async () => '0x'),
+
+    sendTransaction: vi.fn(async (tx) => {
+      provider.sentTxs.push(tx)
+      blockNumber++
+
+      // Extract recipientHash and encryptedPayload from calldata to store as event log
+      const calldata = hexToBytes(tx.data)
+      // calldata: selector(4) + recipientHash(32) + offset(32) + length(32) + data(...)
+      const recipientHashBytes = calldata.slice(4, 36)
+      const recipientHashHex =
+        '0x' +
+        Array.from(recipientHashBytes)
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join('')
+
+      // Read payload length and data
+      const lengthWord = calldata.slice(68, 100)
+      let payloadLength = 0
+      for (let i = 28; i < 32; i++) {
+        payloadLength = payloadLength * 256 + lengthWord[i]
+      }
+      const encryptedPayload = calldata.slice(100, 100 + payloadLength)
+      const eventData = encodeEventData(encryptedPayload)
+
+      logs.push({
+        data: eventData,
+        blockNumber,
+        topics: [registry.NOTIFICATION_TOPIC, recipientHashHex],
+      })
+
+      return '0xmocktx' + blockNumber
+    }),
+  }
+  return provider
+}
+
+const CONTRACT = '0x318aE190B77bA39fbcdFA4e84BB7CFD16b846Fcf'
+const STAMP = 'mock-stamp-id'
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('identity: publish + resolve round-trip', () => {
+  it('publishes identity and resolves it back', async () => {
+    const bee = new MockBee()
+    const alice = makeUser()
+
+    const swarmIdentity = {
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      overlay: alice.overlay,
+      ethAddress: alice.ethAddress,
+    }
+
+    // Publish
+    await identity.publish(bee as any, alice.ethAddress, STAMP, swarmIdentity)
+
+    // Resolve
+    const resolved = await identity.resolve(bee as any, alice.ethAddress)
+
+    expect(resolved).not.toBeNull()
+    expect(resolved!.walletPublicKey).toBe(alice.publicKeyHex)
+    expect(resolved!.beePublicKey).toBe(alice.beePublicKey)
+    expect(resolved!.overlay).toBe(alice.overlay)
+  })
+
+  it('returns null for non-existent identity', async () => {
+    const bee = new MockBee()
+    const resolved = await identity.resolve(bee as any, '0x0000000000000000000000000000000000000000')
+    expect(resolved).toBeNull()
+  })
+})
+
+describe('contacts: CRUD operations', () => {
+  it('add, list, update, remove cycle', () => {
+    const alice = makeUser()
+    const swarmId = {
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      overlay: alice.overlay,
+    }
+
+    // Add
+    const contact = contacts.add(alice.ethAddress, 'Alice', swarmId)
+    expect(contact.nickname).toBe('Alice')
+    expect(contact.ethAddress).toBe(alice.ethAddress.toLowerCase())
+
+    // List
+    const all = contacts.list()
+    expect(all).toHaveLength(1)
+
+    // Update
+    const updated = contacts.update(alice.ethAddress, { nickname: 'Alice Updated' })
+    expect(updated.nickname).toBe('Alice Updated')
+
+    // Remove
+    contacts.remove(alice.ethAddress)
+    expect(contacts.list()).toHaveLength(0)
+  })
+
+  it('prevents duplicate contacts', () => {
+    const alice = makeUser()
+    const swarmId = {
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      overlay: alice.overlay,
+    }
+
+    contacts.add(alice.ethAddress, 'Alice', swarmId)
+    expect(() => contacts.add(alice.ethAddress, 'Alice2', swarmId)).toThrow('Contact already exists')
+  })
+})
+
+describe('full messaging flow: Alice ↔ Bob', () => {
+  it('Alice sends message to Bob, Bob reads it', async () => {
+    const bee = new MockBee()
+    const alice = makeUser()
+    const bob = makeUser()
+
+    // Both publish identities
+    await identity.publish(bee as any, alice.ethAddress, STAMP, {
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      overlay: alice.overlay,
+      ethAddress: alice.ethAddress,
+    })
+    await identity.publish(bee as any, bob.ethAddress, STAMP, {
+      walletPublicKey: bob.publicKeyHex,
+      beePublicKey: bob.beePublicKey,
+      overlay: bob.overlay,
+      ethAddress: bob.ethAddress,
+    })
+
+    // Alice resolves Bob and adds as contact
+    const bobIdentity = await identity.resolve(bee as any, bob.ethAddress)
+    expect(bobIdentity).not.toBeNull()
+
+    const bobContact = contacts.add(bob.ethAddress, 'Bob', bobIdentity!)
+
+    // Alice sends a message to Bob
+    await mailbox.send(
+      bee as any,
+      alice.ethAddress, // signer
+      STAMP,
+      alice.privateKey,
+      alice.overlay,
+      bobContact,
+      { subject: 'Hello Bob', body: 'This is a test message from Alice' },
+    )
+
+    // Bob reads messages from Alice
+    const aliceContact = contacts.add(alice.ethAddress, 'Alice', {
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      overlay: alice.overlay,
+    })
+    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.overlay, aliceContact)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].subject).toBe('Hello Bob')
+    expect(messages[0].body).toBe('This is a test message from Alice')
+    expect(messages[0].sender).toBe(alice.overlay)
+    expect(messages[0].v).toBe(1)
+    expect(messages[0].ts).toBeGreaterThan(0)
+  })
+
+  it('multiple messages accumulate in the feed', async () => {
+    const bee = new MockBee()
+    const alice = makeUser()
+    const bob = makeUser()
+
+    const bobContact = {
+      ethAddress: bob.ethAddress.toLowerCase(),
+      nickname: 'Bob',
+      walletPublicKey: bob.publicKeyHex,
+      beePublicKey: bob.beePublicKey,
+      overlay: bob.overlay,
+      addedAt: Date.now(),
+    }
+
+    // Alice sends 3 messages
+    for (let i = 1; i <= 3; i++) {
+      await mailbox.send(
+        bee as any,
+        alice.ethAddress,
+        STAMP,
+        alice.privateKey,
+        alice.overlay,
+        bobContact,
+        { subject: `Message ${i}`, body: `Body ${i}` },
+      )
+    }
+
+    // Bob reads all
+    const aliceContact = {
+      ethAddress: alice.ethAddress.toLowerCase(),
+      nickname: 'Alice',
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      overlay: alice.overlay,
+      addedAt: Date.now(),
+    }
+    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.overlay, aliceContact)
+
+    expect(messages).toHaveLength(3)
+    expect(messages[0].subject).toBe('Message 1')
+    expect(messages[1].subject).toBe('Message 2')
+    expect(messages[2].subject).toBe('Message 3')
+  })
+
+  it('bidirectional conversation via checkInbox', async () => {
+    const bee = new MockBee()
+    const alice = makeUser()
+    const bob = makeUser()
+
+    const bobContact = {
+      ethAddress: bob.ethAddress.toLowerCase(),
+      nickname: 'Bob',
+      walletPublicKey: bob.publicKeyHex,
+      beePublicKey: bob.beePublicKey,
+      overlay: bob.overlay,
+      addedAt: Date.now(),
+    }
+    const aliceContact = {
+      ethAddress: alice.ethAddress.toLowerCase(),
+      nickname: 'Alice',
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      overlay: alice.overlay,
+      addedAt: Date.now(),
+    }
+
+    // Alice → Bob
+    await mailbox.send(bee as any, alice.ethAddress, STAMP, alice.privateKey, alice.overlay, bobContact, {
+      subject: 'Hi Bob',
+      body: 'Hello from Alice',
+    })
+
+    // Bob → Alice
+    await mailbox.send(bee as any, bob.ethAddress, STAMP, bob.privateKey, bob.overlay, aliceContact, {
+      subject: 'Hi Alice',
+      body: 'Hello from Bob',
+    })
+
+    // Alice checks inbox — should see Bob's message
+    const aliceInbox = await mailbox.checkInbox(bee as any, alice.privateKey, alice.overlay, [bobContact])
+    expect(aliceInbox).toHaveLength(1)
+    expect(aliceInbox[0].messages[0].subject).toBe('Hi Alice')
+
+    // Bob checks inbox — should see Alice's message
+    const bobInbox = await mailbox.checkInbox(bee as any, bob.privateKey, bob.overlay, [aliceContact])
+    expect(bobInbox).toHaveLength(1)
+    expect(bobInbox[0].messages[0].subject).toBe('Hi Bob')
+  })
+})
+
+describe('registry notification flow', () => {
+  it('full discovery: send notification → poll → discover sender', async () => {
+    const alice = makeUser()
+    const bob = makeUser()
+    const provider = createMockProvider()
+
+    // Bob sends notification to Alice (first contact)
+    const payload: NotificationPayload = {
+      sender: bob.ethAddress,
+      overlay: bob.overlay,
+      feedTopic: mailbox.feedTopic(bob.overlay, alice.overlay),
+    }
+
+    await registry.sendNotification(
+      provider,
+      CONTRACT,
+      alice.publicKey,
+      alice.ethAddress,
+      payload,
+      bob.privateKey,
+    )
+
+    // Alice polls — discovers Bob
+    const notifications = await registry.pollNotifications(
+      provider,
+      CONTRACT,
+      alice.ethAddress,
+      alice.privateKey,
+    )
+
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0].payload.sender).toBe(bob.ethAddress)
+    expect(notifications[0].payload.overlay).toBe(bob.overlay)
+    expect(notifications[0].payload.feedTopic).toBe(payload.feedTopic)
+    expect(notifications[0].blockNumber).toBe(1)
+  })
+
+  it('spam notifications are silently filtered', async () => {
+    const alice = makeUser()
+    const bob = makeUser()
+    const provider = createMockProvider()
+
+    // Bob sends a valid notification
+    const validPayload: NotificationPayload = {
+      sender: bob.ethAddress,
+      overlay: bob.overlay,
+      feedTopic: 'valid-topic',
+    }
+    await registry.sendNotification(provider, CONTRACT, alice.publicKey, alice.ethAddress, validPayload, bob.privateKey)
+
+    // Spammer sends notification encrypted with a different key (Alice can't decrypt)
+    const spammer = makeUser()
+    const spamPayload: NotificationPayload = {
+      sender: spammer.ethAddress,
+      overlay: spammer.overlay,
+      feedTopic: 'spam-topic',
+    }
+    // Encrypt with spammer's own key instead of Alice's — Alice can't decrypt this
+    const spamBytes = new TextEncoder().encode(JSON.stringify(spamPayload))
+    const spamEncrypted = await eciesEncrypt(spamBytes, spammer.publicKey)
+    const spamEventData = encodeEventData(spamEncrypted)
+
+    // Manually inject spam log with Alice's recipientHash
+    const aliceHash = registry.recipientHash(alice.ethAddress)
+    provider.logs.push({
+      data: spamEventData,
+      blockNumber: 99,
+      topics: [registry.NOTIFICATION_TOPIC, aliceHash],
+    })
+
+    // Alice polls — should only get Bob's valid notification
+    const notifications = await registry.pollNotifications(provider, CONTRACT, alice.ethAddress, alice.privateKey)
+
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0].payload.sender).toBe(bob.ethAddress)
+  })
+
+  it('multiple senders discoverable via polling', async () => {
+    const alice = makeUser()
+    const provider = createMockProvider()
+
+    // Three different senders notify Alice
+    for (let i = 0; i < 3; i++) {
+      const sender = makeUser()
+      const payload: NotificationPayload = {
+        sender: sender.ethAddress,
+        overlay: sender.overlay,
+        feedTopic: `topic-${i}`,
+      }
+      await registry.sendNotification(provider, CONTRACT, alice.publicKey, alice.ethAddress, payload, sender.privateKey)
+    }
+
+    const notifications = await registry.pollNotifications(provider, CONTRACT, alice.ethAddress, alice.privateKey)
+    expect(notifications).toHaveLength(3)
+    expect(notifications[0].payload.feedTopic).toBe('topic-0')
+    expect(notifications[1].payload.feedTopic).toBe('topic-1')
+    expect(notifications[2].payload.feedTopic).toBe('topic-2')
+  })
+
+  it('fromBlock filters old notifications', async () => {
+    const alice = makeUser()
+    const provider = createMockProvider()
+
+    // Send two notifications (block 1 and block 2)
+    for (let i = 0; i < 2; i++) {
+      const sender = makeUser()
+      await registry.sendNotification(
+        provider,
+        CONTRACT,
+        alice.publicKey,
+        alice.ethAddress,
+        { sender: sender.ethAddress, overlay: sender.overlay, feedTopic: `topic-${i}` },
+        sender.privateKey,
+      )
+    }
+
+    // Poll from block 2 — should only get the second one
+    const notifications = await registry.pollNotifications(provider, CONTRACT, alice.ethAddress, alice.privateKey, 2)
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0].payload.feedTopic).toBe('topic-1')
+  })
+})
+
+describe('end-to-end: discovery → messaging', () => {
+  it('Bob discovers Alice via registry, then reads her message', async () => {
+    const bee = new MockBee()
+    const provider = createMockProvider()
+    const alice = makeUser()
+    const bob = makeUser()
+
+    // 1. Both publish identities
+    await identity.publish(bee as any, alice.ethAddress, STAMP, {
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      overlay: alice.overlay,
+      ethAddress: alice.ethAddress,
+    })
+    await identity.publish(bee as any, bob.ethAddress, STAMP, {
+      walletPublicKey: bob.publicKeyHex,
+      beePublicKey: bob.beePublicKey,
+      overlay: bob.overlay,
+      ethAddress: bob.ethAddress,
+    })
+
+    // 2. Alice resolves Bob and sends a message
+    const bobId = await identity.resolve(bee as any, bob.ethAddress)
+    const bobContact = {
+      ethAddress: bob.ethAddress.toLowerCase(),
+      nickname: 'Bob',
+      walletPublicKey: bobId!.walletPublicKey,
+      beePublicKey: bobId!.beePublicKey,
+      overlay: bobId!.overlay,
+      addedAt: Date.now(),
+    }
+
+    await mailbox.send(bee as any, alice.ethAddress, STAMP, alice.privateKey, alice.overlay, bobContact, {
+      subject: 'Project files',
+      body: 'Attached the latest version',
+    })
+
+    // 3. Alice sends on-chain notification to Bob (first contact)
+    const feedTopic = mailbox.feedTopic(alice.overlay, bob.overlay)
+    await registry.sendNotification(
+      provider,
+      CONTRACT,
+      bob.publicKey,
+      bob.ethAddress,
+      { sender: alice.ethAddress, overlay: alice.overlay, feedTopic },
+      alice.privateKey,
+    )
+
+    // 4. Bob polls registry — discovers Alice
+    const notifications = await registry.pollNotifications(provider, CONTRACT, bob.ethAddress, bob.privateKey)
+    expect(notifications).toHaveLength(1)
+
+    const discovered = notifications[0].payload
+    expect(discovered.sender).toBe(alice.ethAddress)
+
+    // 5. Bob resolves Alice's identity from discovered ETH address
+    const aliceId = await identity.resolve(bee as any, discovered.sender)
+    expect(aliceId).not.toBeNull()
+
+    // 6. Bob reads messages from Alice
+    const aliceContact = {
+      ethAddress: discovered.sender.toLowerCase(),
+      nickname: 'Alice',
+      walletPublicKey: aliceId!.walletPublicKey,
+      beePublicKey: aliceId!.beePublicKey,
+      overlay: aliceId!.overlay,
+      addedAt: Date.now(),
+    }
+    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.overlay, aliceContact)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].subject).toBe('Project files')
+    expect(messages[0].body).toBe('Attached the latest version')
+  })
+})

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: ['test/e2e.test.ts', 'node_modules/**'],
+    include: ['test/e2e.test.ts'],
+    testTimeout: 120000,
   },
 })


### PR DESCRIPTION
## Summary
- **CLI reference app** (`examples/cli.ts`) — commander subcommands for identity, contacts, mailbox, and registry. Includes `NotifyProvider` wrapper (`examples/provider.ts`) and detailed README with flow diagram and two-terminal demo walkthrough.
- **Integration tests** (`test/integration.test.ts`) — 12 tests covering full flow with mocked Bee + NotifyProvider: identity publish/resolve, contacts CRUD, bidirectional messaging, registry notifications, spam filtering, multi-contact inbox.
- **E2E tests** (`test/e2e.test.ts`) — 6 tests against real Bee node and Gnosis Chain: identity, mailbox, registry, and full discovery-to-message flow. Run separately with `npm run test:e2e`.
- **Mock Bee helper** (`test/helpers/mock-bee.ts`) — in-memory feed/blob storage for integration tests.

## Test plan
- [x] `npm test` — 64 tests pass (unit + integration, mocked)
- [x] `npm run test:e2e` — 6 tests pass (real Bee node + Gnosis Chain)
- [x] `npm run check:types` — clean
- [x] `npm run cli -- --help` — shows all commands with descriptions
- [x] `npm run cli -- contacts list` — works

Closes #11