### PR TITLE
Fix #3: Remove unused _senderPrivateKey from sendNotification

### DIFF
--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -341,7 +341,6 @@ registryCmd
       recipientPubKey,
       contact.ethAddress,
       { sender: myAddress, overlay: myOverlay, feedTopic },
-      privKey,
     )
 
     console.log(`Notification sent to ${contact.nickname}`)

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -149,7 +149,6 @@ export function recipientHash(ethAddress: string): string {
  * @param recipientPublicKey - Recipient's compressed secp256k1 public key (33 bytes)
  * @param recipientEthAddress - Recipient's ETH address
  * @param payload - Notification payload (sender info + feed topic)
- * @param _senderPrivateKey - Sender's private key (reserved for future use, e.g. signing)
  * @returns Transaction hash
  */
 export async function sendNotification(
@@ -158,7 +157,6 @@ export async function sendNotification(
   recipientPublicKey: Uint8Array,
   recipientEthAddress: string,
   payload: NotificationPayload,
-  _senderPrivateKey: Uint8Array,
 ): Promise<string> {
   // 1. JSON-encode and ECIES-encrypt the payload
   const payloadBytes = new TextEncoder().encode(JSON.stringify(payload))

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -227,7 +227,6 @@ describe('registry: real Gnosis Chain', () => {
       secp.getPublicKey(bobPrivateKey, true),
       bobEthAddress,
       payload,
-      privateKey,
     )
 
     expect(txHash).toMatch(/^0x[0-9a-fA-F]{64}$/)
@@ -312,7 +311,6 @@ describe('full E2E flow: identity → message → notification → discovery', (
       secp.getPublicKey(charliePrivateKey, true),
       charlieEthAddress,
       { sender: ethAddress, overlay, feedTopic },
-      privateKey,
     )
     console.log(`  Full flow notification tx: ${txHash}`)
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -372,7 +372,6 @@ describe('registry notification flow', () => {
       alice.publicKey,
       alice.ethAddress,
       payload,
-      bob.privateKey,
     )
 
     // Alice polls — discovers Bob
@@ -401,7 +400,7 @@ describe('registry notification flow', () => {
       overlay: bob.overlay,
       feedTopic: 'valid-topic',
     }
-    await registry.sendNotification(provider, CONTRACT, alice.publicKey, alice.ethAddress, validPayload, bob.privateKey)
+    await registry.sendNotification(provider, CONTRACT, alice.publicKey, alice.ethAddress, validPayload)
 
     // Spammer sends notification encrypted with a different key (Alice can't decrypt)
     const spammer = makeUser()
@@ -442,7 +441,7 @@ describe('registry notification flow', () => {
         overlay: sender.overlay,
         feedTopic: `topic-${i}`,
       }
-      await registry.sendNotification(provider, CONTRACT, alice.publicKey, alice.ethAddress, payload, sender.privateKey)
+      await registry.sendNotification(provider, CONTRACT, alice.publicKey, alice.ethAddress, payload)
     }
 
     const notifications = await registry.pollNotifications(provider, CONTRACT, alice.ethAddress, alice.privateKey)
@@ -465,7 +464,6 @@ describe('registry notification flow', () => {
         alice.publicKey,
         alice.ethAddress,
         { sender: sender.ethAddress, overlay: sender.overlay, feedTopic: `topic-${i}` },
-        sender.privateKey,
       )
     }
 
@@ -521,7 +519,6 @@ describe('end-to-end: discovery → messaging', () => {
       bob.publicKey,
       bob.ethAddress,
       { sender: alice.ethAddress, overlay: alice.overlay, feedTopic },
-      alice.privateKey,
     )
 
     // 4. Bob polls registry — discovers Alice

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -128,15 +128,12 @@ describe('ABI encoding', () => {
     const provider = createMockProvider()
     const recipientPrivKey = secp.utils.randomPrivateKey()
     const recipientPubKey = secp.getPublicKey(recipientPrivKey, true)
-    const senderPrivKey = secp.utils.randomPrivateKey()
-
     await sendNotification(
       provider,
       CONTRACT_ADDRESS,
       recipientPubKey,
       '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       SAMPLE_PAYLOAD,
-      senderPrivKey,
     )
 
     const sentData = provider.sentTxs[0].data
@@ -150,7 +147,6 @@ describe('ABI encoding', () => {
     const provider = createMockProvider()
     const recipientPrivKey = secp.utils.randomPrivateKey()
     const recipientPubKey = secp.getPublicKey(recipientPrivKey, true)
-    const senderPrivKey = secp.utils.randomPrivateKey()
     const recipientAddr = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
     await sendNotification(
@@ -159,7 +155,6 @@ describe('ABI encoding', () => {
       recipientPubKey,
       recipientAddr,
       SAMPLE_PAYLOAD,
-      senderPrivKey,
     )
 
     const sentData = provider.sentTxs[0].data
@@ -174,15 +169,12 @@ describe('sendNotification', () => {
     const provider = createMockProvider()
     const recipientPrivKey = secp.utils.randomPrivateKey()
     const recipientPubKey = secp.getPublicKey(recipientPrivKey, true)
-    const senderPrivKey = secp.utils.randomPrivateKey()
-
     const txHash = await sendNotification(
       provider,
       CONTRACT_ADDRESS,
       recipientPubKey,
       '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       SAMPLE_PAYLOAD,
-      senderPrivKey,
     )
 
     expect(txHash).toBe('0xmocktxhash')
@@ -194,7 +186,6 @@ describe('sendNotification', () => {
     const provider = createMockProvider()
     const recipientPrivKey = secp.utils.randomPrivateKey()
     const recipientPubKey = secp.getPublicKey(recipientPrivKey, true)
-    const senderPrivKey = secp.utils.randomPrivateKey()
     const recipientAddr = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 
     await sendNotification(
@@ -203,7 +194,6 @@ describe('sendNotification', () => {
       recipientPubKey,
       recipientAddr,
       SAMPLE_PAYLOAD,
-      senderPrivKey,
     )
 
     // Extract encrypted payload from calldata and verify it's decryptable


### PR DESCRIPTION
## Summary
- Remove unused `_senderPrivateKey: Uint8Array` parameter from `sendNotification()`
- Update all 12 call sites (registry tests, integration tests, E2E tests, CLI)
- Remove 4 now-unused variable declarations in registry tests

Addresses review item #3 in #16.

## Test plan
- [x] `npm test` — 64 tests pass
- [x] `npm run check:types` — clean