### PR TITLE
Fix #4: Remove localStorage from contacts, make in-memory

### DIFF
--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -6,12 +6,9 @@
  * Or:    npm run cli -- <command> [options]
  */
 
-// localStorage polyfill — must be set before importing contacts module
-import { LocalStorage } from 'node-localstorage'
-const store = new LocalStorage('./data/contacts')
-;(globalThis as any).localStorage = store
-
 import 'dotenv/config'
+import * as fs from 'fs'
+import * as path from 'path'
 import { Command } from 'commander'
 import { Bee } from '@ethersphere/bee-js'
 import * as secp from '@noble/secp256k1'
@@ -20,9 +17,27 @@ import { keccak_256 } from '@noble/hashes/sha3'
 
 import * as identity from '../src/identity'
 import * as mailbox from '../src/mailbox'
-import * as contacts from '../src/contacts'
+import { ContactStore } from '../src/contacts'
 import * as registry from '../src/registry'
 import { createReadOnlyProvider, createSigningProvider } from './provider'
+
+// ─── Contact persistence (file-based, CLI layer) ────────────────
+
+const CONTACTS_FILE = path.resolve('./data/contacts.json')
+
+function loadContacts(): ContactStore {
+  try {
+    const raw = fs.readFileSync(CONTACTS_FILE, 'utf-8')
+    return ContactStore.from(JSON.parse(raw))
+  } catch {
+    return new ContactStore()
+  }
+}
+
+function saveContacts(store: ContactStore): void {
+  fs.mkdirSync(path.dirname(CONTACTS_FILE), { recursive: true })
+  fs.writeFileSync(CONTACTS_FILE, JSON.stringify(store.export(), null, 2))
+}
 
 // ─── Config ─────────────────────────────────────────────────────
 
@@ -161,7 +176,9 @@ contactsCmd
       swarmId = resolved
     }
 
-    const contact = contacts.add(ethAddress, nickname, swarmId)
+    const store = loadContacts()
+    const contact = store.add(ethAddress, nickname, swarmId)
+    saveContacts(store)
     console.log(`Contact added: ${contact.nickname} (${contact.ethAddress})`)
   })
 
@@ -170,7 +187,9 @@ contactsCmd
   .description('Remove a contact')
   .argument('<ethAddress>', 'ETH address')
   .action((ethAddress: string) => {
-    contacts.remove(ethAddress)
+    const store = loadContacts()
+    store.remove(ethAddress)
+    saveContacts(store)
     console.log(`Contact removed: ${ethAddress}`)
   })
 
@@ -178,7 +197,7 @@ contactsCmd
   .command('list')
   .description('List all contacts')
   .action(() => {
-    const all = contacts.list()
+    const all = loadContacts().list()
     if (all.length === 0) {
       console.log('No contacts.')
       return
@@ -213,7 +232,7 @@ mailboxCmd
       process.exit(1)
     }
 
-    const contact = contacts.list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
+    const contact = loadContacts().list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
     if (!contact) {
       console.error(`Contact not found: ${ethAddress}. Add them first with 'contacts add'.`)
       process.exit(1)
@@ -244,7 +263,7 @@ mailboxCmd
       process.exit(1)
     }
 
-    const contact = contacts.list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
+    const contact = loadContacts().list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
     if (!contact) {
       console.error(`Contact not found: ${ethAddress}`)
       process.exit(1)
@@ -280,7 +299,7 @@ mailboxCmd
       process.exit(1)
     }
 
-    const allContacts = contacts.list()
+    const allContacts = loadContacts().list()
     if (allContacts.length === 0) {
       console.log('No contacts. Add some first.')
       return
@@ -325,7 +344,7 @@ registryCmd
       process.exit(1)
     }
 
-    const contact = contacts.list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
+    const contact = loadContacts().list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
     if (!contact) {
       console.error(`Contact not found: ${ethAddress}. Add them first.`)
       process.exit(1)

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -1,74 +1,91 @@
 import type { Contact, SwarmIdentity } from './types'
 
-const STORAGE_KEY = 'swarm-notify-contacts'
-
-function readStore(): Contact[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    return raw ? JSON.parse(raw) : []
-  } catch {
-    return []
-  }
-}
-
-function writeStore(contacts: Contact[]): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(contacts))
-}
-
 /**
- * Add a contact. Stores identity info locally for quick access.
+ * In-memory contact store. Host apps are responsible for persistence
+ * (localStorage, file, database — whatever fits their platform).
+ *
+ * Usage:
+ *   const store = new ContactStore()
+ *   store.add('0x...', 'Alice', identity)
+ *   const all = store.list()
+ *
+ * To persist, serialize with store.export() and restore with ContactStore.from(data).
  */
-export function add(ethAddress: string, nickname: string, identity: SwarmIdentity): Contact {
-  const contacts = readStore()
-  const existing = contacts.find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
-  if (existing) {
-    throw new Error(`Contact already exists: ${ethAddress}`)
+export class ContactStore {
+  private contacts: Contact[] = []
+
+  /**
+   * Create a store from previously exported data (for persistence).
+   */
+  static from(data: Contact[]): ContactStore {
+    const store = new ContactStore()
+    store.contacts = [...data]
+    return store
   }
 
-  const contact: Contact = {
-    ethAddress: ethAddress.toLowerCase(),
-    nickname,
-    walletPublicKey: identity.walletPublicKey,
-    beePublicKey: identity.beePublicKey,
-    overlay: identity.overlay,
-    addedAt: Date.now(),
+  /**
+   * Add a contact. Stores identity info for quick access.
+   * Throws if contact already exists (case-insensitive ETH address match).
+   */
+  add(ethAddress: string, nickname: string, identity: SwarmIdentity): Contact {
+    const existing = this.contacts.find(
+      (c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase(),
+    )
+    if (existing) {
+      throw new Error(`Contact already exists: ${ethAddress}`)
+    }
+
+    const contact: Contact = {
+      ethAddress: ethAddress.toLowerCase(),
+      nickname,
+      walletPublicKey: identity.walletPublicKey,
+      beePublicKey: identity.beePublicKey,
+      overlay: identity.overlay,
+      addedAt: Date.now(),
+    }
+    this.contacts.push(contact)
+    return contact
   }
-  contacts.push(contact)
-  writeStore(contacts)
-  return contact
-}
 
-/**
- * Remove a contact by ETH address. Stops checking their feed.
- */
-export function remove(ethAddress: string): void {
-  const contacts = readStore()
-  const filtered = contacts.filter((c) => c.ethAddress.toLowerCase() !== ethAddress.toLowerCase())
-  writeStore(filtered)
-}
-
-/**
- * List all contacts.
- */
-export function list(): Contact[] {
-  return readStore()
-}
-
-/**
- * Update a contact's nickname or refresh cached identity keys.
- */
-export function update(
-  ethAddress: string,
-  changes: Partial<Pick<Contact, 'nickname' | 'overlay' | 'walletPublicKey' | 'beePublicKey'>>,
-): Contact {
-  const contacts = readStore()
-  const index = contacts.findIndex(
-    (c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase(),
-  )
-  if (index === -1) {
-    throw new Error(`Contact not found: ${ethAddress}`)
+  /**
+   * Remove a contact by ETH address (case-insensitive).
+   */
+  remove(ethAddress: string): void {
+    this.contacts = this.contacts.filter(
+      (c) => c.ethAddress.toLowerCase() !== ethAddress.toLowerCase(),
+    )
   }
-  contacts[index] = { ...contacts[index], ...changes }
-  writeStore(contacts)
-  return contacts[index]
+
+  /**
+   * List all contacts.
+   */
+  list(): Contact[] {
+    return [...this.contacts]
+  }
+
+  /**
+   * Update a contact's nickname or refresh cached identity keys.
+   * Throws if contact not found.
+   */
+  update(
+    ethAddress: string,
+    changes: Partial<Pick<Contact, 'nickname' | 'overlay' | 'walletPublicKey' | 'beePublicKey'>>,
+  ): Contact {
+    const index = this.contacts.findIndex(
+      (c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase(),
+    )
+    if (index === -1) {
+      throw new Error(`Contact not found: ${ethAddress}`)
+    }
+    this.contacts[index] = { ...this.contacts[index], ...changes }
+    return this.contacts[index]
+  }
+
+  /**
+   * Export contacts for persistence. Returns a plain array that can be
+   * JSON.stringify'd and later restored with ContactStore.from().
+   */
+  export(): Contact[] {
+    return [...this.contacts]
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export * as crypto from './crypto'
 export * as identity from './identity'
 export * as mailbox from './mailbox'
-export * as contacts from './contacts'
+export { ContactStore } from './contacts'
 export * as registry from './registry'
 
 export type {

--- a/test/contacts.test.ts
+++ b/test/contacts.test.ts
@@ -1,6 +1,5 @@
-// @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest'
-import { add, remove, list, update } from '../src/contacts'
+import { ContactStore } from '../src/contacts'
 
 const mockIdentity = {
   walletPublicKey: '02' + 'ab'.repeat(32),
@@ -8,13 +7,15 @@ const mockIdentity = {
   overlay: 'ff'.repeat(32),
 }
 
+let store: ContactStore
+
 beforeEach(() => {
-  localStorage.clear()
+  store = new ContactStore()
 })
 
 describe('add', () => {
   it('creates contact with all fields', () => {
-    const contact = add('0x1234567890abcdef1234567890abcdef12345678', 'Alice', mockIdentity)
+    const contact = store.add('0x1234567890abcdef1234567890abcdef12345678', 'Alice', mockIdentity)
 
     expect(contact.ethAddress).toBe('0x1234567890abcdef1234567890abcdef12345678')
     expect(contact.nickname).toBe('Alice')
@@ -25,28 +26,28 @@ describe('add', () => {
   })
 
   it('throws on duplicate ethAddress', () => {
-    add('0x1234567890abcdef1234567890abcdef12345678', 'Alice', mockIdentity)
+    store.add('0x1234567890abcdef1234567890abcdef12345678', 'Alice', mockIdentity)
     expect(() =>
-      add('0x1234567890abcdef1234567890abcdef12345678', 'Alice2', mockIdentity),
+      store.add('0x1234567890abcdef1234567890abcdef12345678', 'Alice2', mockIdentity),
     ).toThrow('Contact already exists')
   })
 
   it('duplicate check is case-insensitive', () => {
-    add('0xabcdef1234567890abcdef1234567890abcdef12', 'Alice', mockIdentity)
+    store.add('0xabcdef1234567890abcdef1234567890abcdef12', 'Alice', mockIdentity)
     expect(() =>
-      add('0xABCDEF1234567890ABCDEF1234567890ABCDEF12', 'Alice2', mockIdentity),
+      store.add('0xABCDEF1234567890ABCDEF1234567890ABCDEF12', 'Alice2', mockIdentity),
     ).toThrow('Contact already exists')
   })
 })
 
 describe('remove', () => {
   it('removes contact from list', () => {
-    add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
-    add('0x2222222222222222222222222222222222222222', 'Bob', mockIdentity)
+    store.add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
+    store.add('0x2222222222222222222222222222222222222222', 'Bob', mockIdentity)
 
-    remove('0x1111111111111111111111111111111111111111')
+    store.remove('0x1111111111111111111111111111111111111111')
 
-    const contacts = list()
+    const contacts = store.list()
     expect(contacts).toHaveLength(1)
     expect(contacts[0].nickname).toBe('Bob')
   })
@@ -54,34 +55,41 @@ describe('remove', () => {
 
 describe('list', () => {
   it('returns empty array when no contacts', () => {
-    expect(list()).toEqual([])
+    expect(store.list()).toEqual([])
   })
 
   it('returns all contacts', () => {
-    add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
-    add('0x2222222222222222222222222222222222222222', 'Bob', mockIdentity)
+    store.add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
+    store.add('0x2222222222222222222222222222222222222222', 'Bob', mockIdentity)
 
-    expect(list()).toHaveLength(2)
+    expect(store.list()).toHaveLength(2)
+  })
+
+  it('returns a copy (mutations do not affect store)', () => {
+    store.add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
+    const list = store.list()
+    list.pop()
+    expect(store.list()).toHaveLength(1)
   })
 })
 
 describe('update', () => {
   it('updates nickname', () => {
-    add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
+    store.add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
 
-    const updated = update('0x1111111111111111111111111111111111111111', {
+    const updated = store.update('0x1111111111111111111111111111111111111111', {
       nickname: 'Alice Updated',
     })
 
     expect(updated.nickname).toBe('Alice Updated')
-    expect(list()[0].nickname).toBe('Alice Updated')
+    expect(store.list()[0].nickname).toBe('Alice Updated')
   })
 
   it('updates overlay (key refresh)', () => {
-    add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
+    store.add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
 
     const newOverlay = 'aa'.repeat(32)
-    const updated = update('0x1111111111111111111111111111111111111111', {
+    const updated = store.update('0x1111111111111111111111111111111111111111', {
       overlay: newOverlay,
     })
 
@@ -90,7 +98,28 @@ describe('update', () => {
 
   it('throws if contact not found', () => {
     expect(() =>
-      update('0x0000000000000000000000000000000000000000', { nickname: 'Nobody' }),
+      store.update('0x0000000000000000000000000000000000000000', { nickname: 'Nobody' }),
     ).toThrow('Contact not found')
+  })
+})
+
+describe('export / from', () => {
+  it('round-trips through export and from', () => {
+    store.add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
+    store.add('0x2222222222222222222222222222222222222222', 'Bob', mockIdentity)
+
+    const exported = store.export()
+    const restored = ContactStore.from(exported)
+
+    expect(restored.list()).toHaveLength(2)
+    expect(restored.list()[0].nickname).toBe('Alice')
+    expect(restored.list()[1].nickname).toBe('Bob')
+  })
+
+  it('export returns a copy', () => {
+    store.add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
+    const exported = store.export()
+    exported.pop()
+    expect(store.list()).toHaveLength(1)
   })
 })

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 /**
  * Integration tests — exercise the full library flow end-to-end
  * with mocked Bee node and NotifyProvider.
@@ -10,7 +9,7 @@ import { keccak_256 } from '@noble/hashes/sha3'
 import { MockBee } from './helpers/mock-bee'
 import * as identity from '../src/identity'
 import * as mailbox from '../src/mailbox'
-import * as contacts from '../src/contacts'
+import { ContactStore } from '../src/contacts'
 import * as registry from '../src/registry'
 import { eciesEncrypt } from '../src/crypto'
 import type { NotifyProvider, NotificationPayload } from '../src/types'
@@ -135,8 +134,10 @@ const STAMP = 'mock-stamp-id'
 
 // ─── Tests ──────────────────────────────────────────────────────
 
+let contacts: ContactStore
+
 beforeEach(() => {
-  localStorage.clear()
+  contacts = new ContactStore()
 })
 
 describe('identity: publish + resolve round-trip', () => {


### PR DESCRIPTION
## Summary
- Replace global `localStorage`-backed contacts with `ContactStore` class (in-memory)
- `ContactStore.from(data)` / `store.export()` for persistence — host apps decide how
- CLI now uses file-based persistence (`data/contacts.json`)
- No more `jsdom` dependency in tests
- Dissolves review item #5 (silent data loss) — no implicit persistence to corrupt

Addresses review items #4 and #5 in #16.

## Test plan
- [x] `npm test` — 67 tests pass (3 new: export/from round-trip + copy safety)
- [x] `npm run check:types` — clean