### PR TITLE
Fix #2: CLI passes private key as signer, not ETH address

### DIFF
--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -45,6 +45,10 @@ function getPrivateKey(): Uint8Array {
   return bytes
 }
 
+function getPrivateKeyHex(privateKey: Uint8Array): string {
+  return '0x' + bytesToHex(privateKey)
+}
+
 function getPublicKeyHex(privateKey: Uint8Array): string {
   return bytesToHex(secp.getPublicKey(privateKey, true))
 }
@@ -98,8 +102,8 @@ identityCmd
     const ethAddress = getEthAddress(privKey)
     const pubKeyHex = getPublicKeyHex(privKey)
 
-    // Use ethAddress as signer for the feed
-    await identity.publish(bee, ethAddress, stamp, {
+    // Signer must be the private key, not the ETH address
+    await identity.publish(bee, getPrivateKeyHex(privKey), stamp, {
       walletPublicKey: pubKeyHex,
       beePublicKey: pubKeyHex, // Using wallet key as bee key for CLI simplicity
       overlay,
@@ -219,7 +223,7 @@ mailboxCmd
       process.exit(1)
     }
 
-    await mailbox.send(bee, myAddress, stamp, privKey, myOverlay, contact, {
+    await mailbox.send(bee, getPrivateKeyHex(privKey), stamp, privKey, myOverlay, contact, {
       subject: opts.subject,
       body: opts.body,
     })


### PR DESCRIPTION
## Summary
- Fix `identity.publish` call: pass private key hex instead of ETH address as signer
- Fix `mailbox.send` call: same fix
- Add `getPrivateKeyHex()` helper for consistent signer formatting

Both `bee.makeFeedWriter(topic, signer)` calls expect a 32-byte private key. The CLI was passing a 20-byte ETH address, causing feeds to be written under an unreachable owner.

Addresses review item #2 in #16.

## Test plan
- [x] `npm test` — 64 tests pass
- [x] E2E tests already use the correct signer (fixed independently in test/e2e.test.ts)