### PR TITLE
Fix #1: Sync CLAUDE.md and integration guide with real API signatures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,14 +187,14 @@ interface NotifyProvider {
 // ─── crypto.ts ───────────────────────────────────────────────────
 
 function deriveSharedSecret(myPrivateKey: Uint8Array, theirPublicKey: Uint8Array): Uint8Array
-function encrypt(plaintext: Uint8Array, sharedSecret: Uint8Array): EncryptedData
-function decrypt(encrypted: EncryptedData, sharedSecret: Uint8Array): Uint8Array
-function eciesEncrypt(data: Uint8Array, recipientPublicKey: Uint8Array): Uint8Array
-function eciesDecrypt(blob: Uint8Array, myPrivateKey: Uint8Array): Uint8Array
+function encrypt(plaintext: Uint8Array, sharedSecret: Uint8Array): Promise<EncryptedData>
+function decrypt(encrypted: EncryptedData, sharedSecret: Uint8Array): Promise<Uint8Array>
+function eciesEncrypt(data: Uint8Array, recipientPublicKey: Uint8Array): Promise<Uint8Array>
+function eciesDecrypt(blob: Uint8Array, myPrivateKey: Uint8Array): Promise<Uint8Array>
 
 // ─── identity.ts ─────────────────────────────────────────────────
 
-function publish(bee: Bee, signer: Signer, stamp: string, identity: SwarmIdentity): Promise<void>
+function publish(bee: Bee, signer: string | Uint8Array, stamp: string, identity: SwarmIdentity): Promise<void>
 function resolve(bee: Bee, ethAddress: string): Promise<SwarmIdentity | null>
 function feedTopic(ethAddress: string): string  // returns keccak256("swarm-identity-" + ethAddress)
 // NOTE: ENS resolution is NOT in this library — host app resolves ENS → ETH address,
@@ -202,26 +202,29 @@ function feedTopic(ethAddress: string): string  // returns keccak256("swarm-iden
 
 // ─── mailbox.ts ──────────────────────────────────────────────────
 
-function send(bee: Bee, signer: Signer, stamp: string, recipient: Contact, message: Omit<Message, 'ts' | 'sender'>): Promise<void>
-function readMessages(bee: Bee, signer: Signer, contact: Contact, myOverlay: string): Promise<Message[]>
-function checkInbox(bee: Bee, signer: Signer, contacts: Contact[], myOverlay: string): Promise<{ contact: Contact; messages: Message[] }[]>
+function send(bee: Bee, signer: string | Uint8Array, stamp: string, myPrivateKey: Uint8Array, myOverlay: string, recipient: Contact, message: Omit<Message, 'v' | 'ts' | 'sender'>): Promise<void>
+function readMessages(bee: Bee, myPrivateKey: Uint8Array, myOverlay: string, contact: Contact): Promise<Message[]>
+function checkInbox(bee: Bee, myPrivateKey: Uint8Array, myOverlay: string, contacts: Contact[]): Promise<{ contact: Contact; messages: Message[] }[]>
 function feedTopic(senderOverlay: string, recipientOverlay: string): string
 
 // ─── contacts.ts ─────────────────────────────────────────────────
+// ContactStore is an in-memory class. Host apps handle persistence.
 
-function add(ethAddress: string, nickname: string, identity: SwarmIdentity): Contact
-function remove(ethAddress: string): void
-function list(): Contact[]
-function update(ethAddress: string, changes: Partial<Pick<Contact, 'nickname' | 'overlay' | 'walletPublicKey' | 'beePublicKey'>>): Contact
-// NOTE: importFromGranteeLabels is NOT in this library — it's Nook-specific.
-// Host apps import contacts however they want, then call contacts.add().
+class ContactStore {
+  static from(data: Contact[]): ContactStore
+  add(ethAddress: string, nickname: string, identity: SwarmIdentity): Contact
+  remove(ethAddress: string): void
+  list(): Contact[]
+  update(ethAddress: string, changes: Partial<Pick<Contact, 'nickname' | 'overlay' | 'walletPublicKey' | 'beePublicKey'>>): Contact
+  export(): Contact[]
+}
 
 // ─── registry.ts ─────────────────────────────────────────────────
 // Uses NotifyProvider (framework-agnostic) — NOT ethers Provider directly.
 // Host app wraps its own provider. See NotifyProvider interface above.
 
-function sendNotification(provider: NotifyProvider, recipientEthAddress: string, payload: NotificationPayload, senderPrivateKey: Uint8Array): Promise<string>  // returns txHash
-function pollNotifications(provider: NotifyProvider, myEthAddress: string, myPrivateKey: Uint8Array, fromBlock?: number): Promise<{ payload: NotificationPayload; blockNumber: number }[]>
+function sendNotification(provider: NotifyProvider, contractAddress: string, recipientPublicKey: Uint8Array, recipientEthAddress: string, payload: NotificationPayload): Promise<string>
+function pollNotifications(provider: NotifyProvider, contractAddress: string, myEthAddress: string, myPrivateKey: Uint8Array, fromBlock?: number): Promise<{ payload: NotificationPayload; blockNumber: number }[]>
 function recipientHash(ethAddress: string): string  // returns keccak256(ethAddress)
 ```
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -17,7 +17,7 @@ npm install @swarm-notify/sdk @ethersphere/bee-js
 
 ```typescript
 import { Bee } from '@ethersphere/bee-js'
-import { identity, mailbox, contacts, crypto, registry } from '@swarm-notify/sdk'
+import { identity, mailbox, ContactStore, crypto, registry } from '@swarm-notify/sdk'
 import type { NotifyProvider } from '@swarm-notify/sdk'
 
 const bee = new Bee('http://localhost:1633')
@@ -121,9 +121,11 @@ const alice = await identity.resolve(bee, ethAddress)
 
 ## 4. Add as contact
 
-Save the resolved identity as a contact. Contacts determine which feeds to poll.
+Create a `ContactStore` and save the resolved identity. The store is in-memory — your app handles persistence (localStorage, file, database).
 
 ```typescript
+const contacts = new ContactStore()
+
 const aliceContact = contacts.add(
   alice.ethAddress!,
   'Alice',         // nickname
@@ -137,6 +139,17 @@ Other contact operations:
 contacts.list()                                    // all contacts
 contacts.update(ethAddress, { nickname: 'Ali' })   // update fields
 contacts.remove(ethAddress)                        // stop tracking
+```
+
+Persistence — serialize and restore:
+
+```typescript
+// Save to your storage
+const json = JSON.stringify(contacts.export())
+localStorage.setItem('contacts', json)
+
+// Restore later
+const restored = ContactStore.from(JSON.parse(localStorage.getItem('contacts')!))
 ```
 
 ## 5. Send a message
@@ -239,7 +252,6 @@ await registry.sendNotification(
     overlay: myOverlayAddress,
     feedTopic: mailbox.feedTopic(myOverlayAddress, aliceContact.overlay),
   },
-  myEncryptionPrivKey,
 )
 ```
 
@@ -275,10 +287,11 @@ Putting it all together — Bob sends Alice a message for the first time:
 
 ```typescript
 import { Bee } from '@ethersphere/bee-js'
-import { identity, mailbox, contacts, registry } from '@swarm-notify/sdk'
+import { identity, mailbox, ContactStore, registry } from '@swarm-notify/sdk'
 
 const bee = new Bee('http://localhost:1633')
 const REGISTRY = '0x...'
+const contacts = new ContactStore()
 
 // ── Bob's setup ──────────────────────────────────────────────
 
@@ -309,7 +322,6 @@ await registry.sendNotification(
   bobNotifyProvider, REGISTRY,
   hexToBytes(alice.walletPublicKey), alice.ethAddress!,
   { sender: bobEthAddress, overlay: bobOverlay, feedTopic: mailbox.feedTopic(bobOverlay, alice.overlay) },
-  bobPrivateKey,
 )
 
 // ── Alice's side ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Reconcile all four drifted function signatures in CLAUDE.md and docs/integration-guide.md:

| Function | What changed |
|----------|-------------|
| `sendNotification` | Added `contractAddress`, `recipientPublicKey`; removed `_senderPrivateKey` |
| `pollNotifications` | Added `contractAddress` |
| `mailbox.send` | Added `myPrivateKey`, `myOverlay`; signer is `string \| Uint8Array` |
| `mailbox.readMessages` | Reordered to `(bee, myPriv, myOverlay, contact)` |

Also:
- Updated contacts docs to reflect `ContactStore` class
- Added `Promise` return types for async crypto functions
- Updated full flow example in integration guide

Addresses review item #1 in #16.