### PR TITLE
Use cases section + demo step badges (#22, #23, #24)

### DIFF
--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -30,6 +30,110 @@
     </div>
   </header>
 
+  <!-- ─── Use Cases ──────────────────────────────── -->
+  <section class="use-cases">
+    <h2>Integration Scenarios</h2>
+    <p class="section-subtitle">Which modules you need depends on how users discover each other. Here are the three main patterns.</p>
+
+    <div class="use-case-grid">
+      <!-- Use Case 1: Stranger sharing -->
+      <div class="use-case-card">
+        <div class="use-case-header uc-full">
+          <h3>Sharing with a Stranger</h3>
+          <span class="uc-badge">Swarm + Gnosis Chain</span>
+        </div>
+        <div class="use-case-scenario">
+          Alice shares an encrypted drive with Bob. Bob has no advance knowledge of Alice.
+          Alice found Bob's address via his <strong>ENS name</strong> (her app resolves <code>bob.eth</code> → ETH address),
+          a <strong>DAO member directory</strong>, or a <strong>project page</strong>.
+        </div>
+        <div class="use-case-flow">
+          <div class="flow-step">Alice publishes identity <span class="net-tag swarm">Swarm</span></div>
+          <div class="flow-step">Alice resolves Bob's ENS → identity <span class="net-tag swarm">Swarm</span></div>
+          <div class="flow-step">Alice sends drive-share message <span class="net-tag swarm">Swarm</span></div>
+          <div class="flow-step">Alice sends on-chain notification <span class="net-tag chain">Gnosis</span></div>
+          <div class="flow-step">Bob polls registry → discovers Alice <span class="net-tag chain">Gnosis</span></div>
+          <div class="flow-step">Bob resolves Alice → reads message <span class="net-tag swarm">Swarm</span></div>
+        </div>
+        <div class="use-case-modules">
+          <span class="mod used">identity</span>
+          <span class="mod used">mailbox</span>
+          <span class="mod used">registry</span>
+          <span class="mod used">crypto</span>
+        </div>
+        <div class="use-case-meta">
+          <strong>Cost:</strong> Postage stamps + ~22k gas (~0.00002 xDAI)
+          <br/><strong>Demo steps:</strong> All (1–8)
+        </div>
+      </div>
+
+      <!-- Use Case 2: Known contacts -->
+      <div class="use-case-card">
+        <div class="use-case-header uc-swarm">
+          <h3>Known Contacts — Direct Messaging</h3>
+          <span class="uc-badge">Swarm Only</span>
+        </div>
+        <div class="use-case-scenario">
+          Alice and Bob already know each other's ETH addresses — exchanged via a
+          <strong>messaging app</strong>, published on a <strong>website</strong>,
+          scanned a <strong>QR code</strong> at a meetup, or listed in a <strong>DAO directory</strong>.
+        </div>
+        <div class="use-case-flow">
+          <div class="flow-step">Both publish identities <span class="net-tag swarm">Swarm</span></div>
+          <div class="flow-step">Both resolve each other <span class="net-tag swarm">Swarm</span></div>
+          <div class="flow-step">Send and read messages directly <span class="net-tag swarm">Swarm</span></div>
+        </div>
+        <div class="use-case-modules">
+          <span class="mod used">identity</span>
+          <span class="mod used">mailbox</span>
+          <span class="mod unused">registry</span>
+          <span class="mod used">crypto</span>
+        </div>
+        <div class="use-case-meta">
+          <strong>Cost:</strong> Postage stamps only — <strong>no gas, no blockchain</strong>
+          <br/><strong>Demo steps:</strong> 1–5, 7–8 (skip step 6)
+          <br/><br/>
+          <em>This is the lightweight path. If both parties know each other, the entire system works without touching a blockchain.</em>
+        </div>
+      </div>
+
+      <!-- Use Case 3: Public inbox -->
+      <div class="use-case-card">
+        <div class="use-case-header uc-full">
+          <h3>Public Inbox — Discoverable by Address</h3>
+          <span class="uc-badge">Swarm + Gnosis Chain</span>
+        </div>
+        <div class="use-case-scenario">
+          A user or project publishes their ETH address publicly — on their <strong>website</strong>,
+          in their <strong>app's about page</strong>, or in a <strong>DAO profile</strong>.
+          Anyone who knows the address can send them encrypted messages.
+        </div>
+        <div class="use-case-flow">
+          <div class="flow-step">Recipient publishes identity (one-time) <span class="net-tag swarm">Swarm</span></div>
+          <div class="flow-step">Sender resolves recipient <span class="net-tag swarm">Swarm</span></div>
+          <div class="flow-step">Sender sends message + notification <span class="net-tag swarm">Swarm</span> <span class="net-tag chain">Gnosis</span></div>
+          <div class="flow-step">Recipient polls → discovers sender <span class="net-tag chain">Gnosis</span></div>
+          <div class="flow-step">Recipient reads messages <span class="net-tag swarm">Swarm</span></div>
+        </div>
+        <div class="use-case-modules">
+          <span class="mod used">identity</span>
+          <span class="mod used">mailbox</span>
+          <span class="mod used">registry</span>
+          <span class="mod used">crypto</span>
+        </div>
+        <div class="use-case-meta">
+          <strong>Cost:</strong> Sender pays ~22k gas for first contact; subsequent messages are free (Swarm only)
+          <br/><strong>Demo steps:</strong> All (1–8)
+          <br/><br/>
+          <em>The registry acts as a permissionless inbox — anyone can notify, spam is filtered by failed ECIES decryption. No server needed.</em>
+        </div>
+      </div>
+    </div>
+
+    <h2 class="demo-title">Interactive Demo</h2>
+    <p class="section-subtitle">Try the flow below. Steps are numbered to match the "Sharing with a stranger" use case. For "Known contacts", skip step 6.</p>
+  </section>
+
   <main class="split">
     <!-- ─── ALICE (left column) ────────────────────── -->
     <section id="alice" class="panel">
@@ -44,6 +148,7 @@
         <div class="card-header">
           <span class="step-num">1</span>
           <h3>Publish Identity (on Swarm)</h3>
+          <span class="uc-tags">All scenarios</span>
         </div>
         <div class="card-body">
           <button id="alice-publish" disabled>Publish to Swarm</button>
@@ -68,6 +173,7 @@
         <div class="card-header">
           <span class="step-num">3</span>
           <h3>Discover Bob (on Swarm)</h3>
+          <span class="uc-tags">All scenarios</span>
         </div>
         <div class="card-body">
           <button id="alice-resolve" disabled>Resolve Bob's Identity</button>
@@ -92,6 +198,7 @@
         <div class="card-header">
           <span class="step-num">4</span>
           <h3>Send Message to Bob (on Swarm)</h3>
+          <span class="uc-tags">All scenarios</span>
         </div>
         <div class="card-body">
           <input id="alice-msg-subject" type="text" placeholder="Subject" value="Hello Bob" disabled />
@@ -120,6 +227,7 @@
         <div class="card-header">
           <span class="step-num">6</span>
           <h3>Notify Bob (On-Chain)</h3>
+          <span class="uc-tags">Stranger sharing, Public inbox</span>
         </div>
         <div class="card-body">
           <button id="alice-notify" disabled>Send Notification</button>
@@ -149,6 +257,7 @@
         <div class="card-header">
           <span class="step-num">8</span>
           <h3>Check Inbox (on Swarm)</h3>
+          <span class="uc-tags">All scenarios</span>
         </div>
         <div class="card-body">
           <button id="alice-inbox" disabled>Check Inbox</button>
@@ -178,6 +287,7 @@
         <div class="card-header">
           <span class="step-num">2</span>
           <h3>Publish Identity (on Swarm)</h3>
+          <span class="uc-tags">All scenarios</span>
         </div>
         <div class="card-body">
           <button id="bob-publish" disabled>Publish to Swarm</button>
@@ -198,6 +308,7 @@
         <div class="card-header">
           <span class="step-num">3</span>
           <h3>Discover Alice (on Swarm)</h3>
+          <span class="uc-tags">All scenarios</span>
         </div>
         <div class="card-body">
           <button id="bob-resolve" disabled>Resolve Alice's Identity</button>
@@ -219,6 +330,7 @@
         <div class="card-header">
           <span class="step-num">5</span>
           <h3>Read Messages from Alice (on Swarm)</h3>
+          <span class="uc-tags">All scenarios</span>
         </div>
         <div class="card-body">
           <button id="bob-read" disabled>Check Inbox</button>
@@ -243,6 +355,7 @@
         <div class="card-header">
           <span class="step-num">6</span>
           <h3>Poll Notifications (on-chain)</h3>
+          <span class="uc-tags">Stranger sharing, Public inbox</span>
         </div>
         <div class="card-body">
           <button id="bob-poll" disabled>Poll Registry</button>
@@ -270,6 +383,7 @@
         <div class="card-header">
           <span class="step-num">7</span>
           <h3>Reply to Alice (on Swarm)</h3>
+          <span class="uc-tags">All scenarios</span>
         </div>
         <div class="card-body">
           <input id="bob-msg-subject" type="text" placeholder="Subject" value="Re: Hello Bob" disabled />

--- a/examples/web/style.css
+++ b/examples/web/style.css
@@ -85,6 +85,190 @@ h1 .subtitle {
   padding-bottom: 0.35rem;
 }
 
+/* ─── Use Cases Section ───────────────────────── */
+
+.use-cases {
+  padding: 1.25rem 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.use-cases h2 {
+  font-size: 1.1rem;
+  margin-bottom: 0.25rem;
+}
+
+.demo-title {
+  margin-top: 1.5rem;
+}
+
+.section-subtitle {
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  margin-bottom: 1rem;
+}
+
+.use-case-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.use-case-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.use-case-header {
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+}
+
+.use-case-header h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.use-case-header.uc-full {
+  background: linear-gradient(135deg, var(--card) 0%, #1e2a3a 100%);
+}
+
+.use-case-header.uc-swarm {
+  background: linear-gradient(135deg, var(--card) 0%, #1a2e28 100%);
+}
+
+.uc-badge {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  background: var(--accent-dim);
+  color: white;
+  white-space: nowrap;
+}
+
+.uc-swarm .uc-badge {
+  background: #166534;
+}
+
+.use-case-scenario {
+  padding: 0.6rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  line-height: 1.6;
+  border-bottom: 1px solid var(--border);
+}
+
+.use-case-scenario strong { color: var(--text); }
+.use-case-scenario code {
+  background: var(--card);
+  padding: 0.1rem 0.25rem;
+  border-radius: 3px;
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  color: var(--accent);
+}
+
+.use-case-flow {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.flow-step {
+  font-size: 0.7rem;
+  padding: 0.2rem 0;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.flow-step::before {
+  content: '→';
+  color: var(--text-dim);
+  font-size: 0.6rem;
+  flex-shrink: 0;
+}
+
+.net-tag {
+  font-size: 0.55rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 0.05rem 0.3rem;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.net-tag.swarm {
+  background: #166534;
+  color: #86efac;
+}
+
+.net-tag.chain {
+  background: #713f12;
+  color: #fde68a;
+}
+
+.use-case-modules {
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--border);
+}
+
+.mod {
+  font-size: 0.65rem;
+  font-family: var(--mono);
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+}
+
+.mod.used {
+  background: #14532d;
+  color: #86efac;
+}
+
+.mod.unused {
+  background: var(--card);
+  color: var(--text-dim);
+  text-decoration: line-through;
+  opacity: 0.5;
+}
+
+.use-case-meta {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  line-height: 1.6;
+  flex-grow: 1;
+}
+
+.use-case-meta em {
+  color: var(--text);
+  font-style: normal;
+  display: block;
+  margin-top: 0.3rem;
+  padding-top: 0.3rem;
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: 1100px) {
+  .use-case-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .overview-box {
   background: var(--surface);
   border: 1px solid var(--accent-dim);
@@ -185,6 +369,15 @@ h1 .subtitle {
 .card-header h3 {
   font-size: 0.85rem;
   font-weight: 600;
+  flex-grow: 1;
+}
+
+.uc-tags {
+  font-size: 0.55rem;
+  color: var(--text-dim);
+  font-style: italic;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .card-body {

--- a/examples/web/tests/demo.spec.ts
+++ b/examples/web/tests/demo.spec.ts
@@ -30,9 +30,22 @@ test.describe('Web Demo UI', () => {
     await expect(page.locator('#cfg-bee')).toHaveValue('http://localhost:1633')
     await expect(page.locator('#cfg-contract')).toHaveValue(/^0x/)
 
+    // Use cases section
+    await expect(page.locator('.use-cases h2').first()).toContainText('Integration Scenarios')
+    await expect(page.locator('.use-case-card')).toHaveCount(3)
+    await expect(page.locator('.use-case-card').nth(0)).toContainText('Sharing with a Stranger')
+    await expect(page.locator('.use-case-card').nth(1)).toContainText('Known Contacts')
+    await expect(page.locator('.use-case-card').nth(2)).toContainText('Public Inbox')
+
+    // Module checklists visible
+    await expect(page.locator('.use-case-card').nth(1).locator('.mod.unused')).toContainText('registry')
+
     // Both panels visible
     await expect(page.locator('#alice h2')).toContainText('Alice')
     await expect(page.locator('#bob h2')).toContainText('Bob')
+
+    // Step cards have use case tags
+    await expect(page.locator('#alice .card-header .uc-tags').first()).toContainText('All scenarios')
 
     // Event log
     await expect(page.locator('.log-header h3')).toContainText('Event Log')

--- a/examples/web/vite.config.ts
+++ b/examples/web/vite.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vite'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
## Summary

Adds an "Integration Scenarios" section to the top of the web UI with three use case cards:

1. **Sharing with a stranger** — full flow (Swarm + Gnosis Chain). Alice finds Bob via ENS, DAO directory, or project page. Uses all modules.
2. **Known contacts — direct messaging** — Swarm only, no blockchain. Addresses exchanged via messaging app, website, QR code, or DAO directory. No registry needed.
3. **Public inbox** — permissionless (Swarm + Gnosis Chain). ETH address published publicly, anyone can message. Spam filtered by ECIES decryption.

Each card shows:
- Scenario description with realistic discovery methods
- Step-by-step flow with Swarm/Gnosis network tags
- Module checklist (used/unused visual indicators)
- Cost summary and demo step mapping

Demo step cards now show which use cases they participate in (e.g. "Stranger sharing, Public inbox" for on-chain steps).

## Test plan
- [x] `npx vite build` — builds cleanly
- [x] Visual check: 3 cards side by side, responsive to single column

Closes #22, #23, #24. Part of #21.