### PR TITLE
Add flow diagrams to use case cards (#21)

### DIFF
--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -47,13 +47,31 @@
           Alice found Bob's address via his <strong>ENS name</strong> (her app resolves <code>bob.eth</code> → ETH address),
           a <strong>DAO member directory</strong>, or a <strong>project page</strong>.
         </div>
-        <div class="use-case-flow">
-          <div class="flow-step">Alice publishes identity <span class="net-tag swarm">Swarm</span></div>
-          <div class="flow-step">Alice resolves Bob's ENS → identity <span class="net-tag swarm">Swarm</span></div>
-          <div class="flow-step">Alice sends drive-share message <span class="net-tag swarm">Swarm</span></div>
-          <div class="flow-step">Alice sends on-chain notification <span class="net-tag chain">Gnosis</span></div>
-          <div class="flow-step">Bob polls registry → discovers Alice <span class="net-tag chain">Gnosis</span></div>
-          <div class="flow-step">Bob resolves Alice → reads message <span class="net-tag swarm">Swarm</span></div>
+        <div class="flow-diagram">
+          <div class="flow-col">
+            <div class="flow-actor alice">Alice</div>
+            <div class="flow-box swarm">publish identity</div>
+            <div class="flow-box swarm">resolve Bob (ENS)</div>
+            <div class="flow-box swarm">send message</div>
+            <div class="flow-box chain">send notification</div>
+          </div>
+          <div class="flow-col flow-mid">
+            <div class="flow-arrow">Swarm feeds</div>
+            <div class="flow-arrow">Swarm feeds</div>
+            <div class="flow-arrow">encrypted blob</div>
+            <div class="flow-arrow chain-arrow">Gnosis Chain tx</div>
+            <div class="flow-arrow chain-arrow">poll events</div>
+            <div class="flow-arrow">read feed</div>
+          </div>
+          <div class="flow-col">
+            <div class="flow-actor bob">Bob</div>
+            <div class="flow-spacer"></div>
+            <div class="flow-spacer"></div>
+            <div class="flow-spacer"></div>
+            <div class="flow-spacer"></div>
+            <div class="flow-box chain">poll registry</div>
+            <div class="flow-box swarm">discover + read</div>
+          </div>
         </div>
         <div class="use-case-modules">
           <span class="mod used">identity</span>
@@ -78,10 +96,27 @@
           <strong>messaging app</strong>, published on a <strong>website</strong>,
           scanned a <strong>QR code</strong> at a meetup, or listed in a <strong>DAO directory</strong>.
         </div>
-        <div class="use-case-flow">
-          <div class="flow-step">Both publish identities <span class="net-tag swarm">Swarm</span></div>
-          <div class="flow-step">Both resolve each other <span class="net-tag swarm">Swarm</span></div>
-          <div class="flow-step">Send and read messages directly <span class="net-tag swarm">Swarm</span></div>
+        <div class="flow-diagram">
+          <div class="flow-col">
+            <div class="flow-actor alice">Alice</div>
+            <div class="flow-box swarm">publish identity</div>
+            <div class="flow-box swarm">resolve Bob</div>
+            <div class="flow-box swarm">send message</div>
+            <div class="flow-box swarm">read reply</div>
+          </div>
+          <div class="flow-col flow-mid">
+            <div class="flow-arrow">Swarm feeds</div>
+            <div class="flow-arrow">Swarm feeds</div>
+            <div class="flow-arrow">encrypted blob</div>
+            <div class="flow-arrow">encrypted blob</div>
+          </div>
+          <div class="flow-col">
+            <div class="flow-actor bob">Bob</div>
+            <div class="flow-box swarm">publish identity</div>
+            <div class="flow-box swarm">resolve Alice</div>
+            <div class="flow-box swarm">read message</div>
+            <div class="flow-box swarm">send reply</div>
+          </div>
         </div>
         <div class="use-case-modules">
           <span class="mod used">identity</span>
@@ -108,12 +143,28 @@
           in their <strong>app's about page</strong>, or in a <strong>DAO profile</strong>.
           Anyone who knows the address can send them encrypted messages.
         </div>
-        <div class="use-case-flow">
-          <div class="flow-step">Recipient publishes identity (one-time) <span class="net-tag swarm">Swarm</span></div>
-          <div class="flow-step">Sender resolves recipient <span class="net-tag swarm">Swarm</span></div>
-          <div class="flow-step">Sender sends message + notification <span class="net-tag swarm">Swarm</span> <span class="net-tag chain">Gnosis</span></div>
-          <div class="flow-step">Recipient polls → discovers sender <span class="net-tag chain">Gnosis</span></div>
-          <div class="flow-step">Recipient reads messages <span class="net-tag swarm">Swarm</span></div>
+        <div class="flow-diagram">
+          <div class="flow-col">
+            <div class="flow-actor alice">Sender</div>
+            <div class="flow-box swarm">resolve recipient</div>
+            <div class="flow-box swarm">send message</div>
+            <div class="flow-box chain">send notification</div>
+          </div>
+          <div class="flow-col flow-mid">
+            <div class="flow-arrow">Swarm feeds</div>
+            <div class="flow-arrow">encrypted blob</div>
+            <div class="flow-arrow chain-arrow">Gnosis Chain tx</div>
+            <div class="flow-arrow chain-arrow">poll events</div>
+            <div class="flow-arrow">read feed</div>
+          </div>
+          <div class="flow-col">
+            <div class="flow-actor bob">Recipient</div>
+            <div class="flow-box swarm">publish identity</div>
+            <div class="flow-spacer"></div>
+            <div class="flow-spacer"></div>
+            <div class="flow-box chain">poll registry</div>
+            <div class="flow-box swarm">read messages</div>
+          </div>
         </div>
         <div class="use-case-modules">
           <span class="mod used">identity</span>

--- a/examples/web/style.css
+++ b/examples/web/style.css
@@ -219,6 +219,86 @@ h1 .subtitle {
   color: #fde68a;
 }
 
+/* ─── Flow Diagrams ──────────────────────────── */
+
+.flow-diagram {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0.3rem;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.65rem;
+}
+
+.flow-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.flow-mid {
+  justify-content: center;
+  padding: 0 0.3rem;
+  min-width: 70px;
+}
+
+.flow-actor {
+  font-weight: 700;
+  font-size: 0.7rem;
+  text-align: center;
+  padding: 0.2rem 0.4rem;
+  border-radius: var(--radius);
+  margin-bottom: 0.15rem;
+}
+
+.flow-actor.alice { color: var(--alice); }
+.flow-actor.bob { color: var(--bob); }
+
+.flow-box {
+  text-align: center;
+  padding: 0.2rem 0.35rem;
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 0.6rem;
+  line-height: 1.3;
+}
+
+.flow-box.swarm {
+  background: #14532d;
+  color: #86efac;
+  border: 1px solid #166534;
+}
+
+.flow-box.chain {
+  background: #451a03;
+  color: #fde68a;
+  border: 1px solid #713f12;
+}
+
+.flow-spacer {
+  height: 1.35rem;
+}
+
+.flow-arrow {
+  font-size: 0.55rem;
+  color: var(--text-dim);
+  text-align: center;
+  padding: 0.15rem 0;
+}
+
+.flow-arrow::before {
+  content: '--->';
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: #166534;
+  display: block;
+  letter-spacing: -0.5px;
+}
+
+.flow-arrow.chain-arrow::before {
+  color: #713f12;
+}
+
 .use-case-modules {
   padding: 0.5rem 0.75rem;
   display: flex;


### PR DESCRIPTION
## Summary

Replaces the text-based flow steps in each use case card with compact visual sequence diagrams:

- **Actor columns** (Alice/Bob or Sender/Recipient) on left and right
- **Step boxes** color-coded: green for Swarm, amber for Gnosis Chain
- **Arrows** with operation labels (Swarm feeds, encrypted blob, Gnosis Chain tx)
- **Use case 2** (known contacts) is visibly all-green — no chain operations

## Test plan
- [x] Playwright tests — 5 pass
- [x] Vite build — clean

Part of #21.