### PR TITLE
chore: add prepare script so git installs build dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/ test/ --fix && prettier --write src/ test/",


### PR DESCRIPTION
## Why

Currently the package can't be installed as a git dependency. \`package.json\` says \`main: dist/index.js\` but \`dist/\` is gitignored, so a consumer running:

\`\`\`
npm install github:GasperX93/swarm-notify#<sha>
\`\`\`

…gets a clone with no built artifacts and \`require('@swarm-notify/sdk')\` fails. This blocks integration in downstream projects (Nook is hitting this now while wiring up the library).

## What

Add a single line to \`scripts\`:

\`\`\`json
\"prepare\": \"npm run build\"
\`\`\`

The \`prepare\` lifecycle hook runs after \`npm install\` in the package's own checkout, including when that checkout was made by npm to install the package as a git dep. Consumers automatically get a built \`dist/\` with no extra setup.

## Test plan

Verified locally:

\`\`\`bash
$ mkdir /tmp/test && cd /tmp/test
$ echo '{\"name\":\"test\",\"version\":\"1.0.0\"}' > package.json
$ npm install github:GasperX93/swarm-notify#chore/add-prepare-script
$ ls node_modules/@swarm-notify/sdk/dist/
contacts.d.ts contacts.js crypto.d.ts crypto.js identity.d.ts identity.js
index.d.ts index.js mailbox.d.ts mailbox.js  ...
$ node -e \"const s = require('@swarm-notify/sdk'); console.log(Object.keys(s).join(', '))\"
crypto, identity, mailbox, contacts, registry
\`\`\`

## Notes

- This is the [npm-recommended way](https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish) to ship pre-build artifacts via git deps without committing \`dist/\`.
- Once the package is published to npm, this becomes redundant for npm users but stays useful for git pins (e.g., to test pre-release SHAs).
- Slightly slows down \`npm install\` in the package itself by one \`tsc\` invocation. Acceptable.