### PR TITLE
fix: guard SharedArrayBuffer check with typeof

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -4,7 +4,12 @@ import type { EncryptedData } from './types'
 
 /** Convert Uint8Array to ArrayBuffer for Web Crypto API (TS 5.8 compatibility) */
 function toBuffer(arr: Uint8Array): ArrayBuffer {
-  return arr.buffer instanceof SharedArrayBuffer
+  // `SharedArrayBuffer` is undefined in browsers without cross-origin isolation
+  // (Brave by default, and any non-COOP/COEP page). Guard with `typeof` so the
+  // `instanceof` check doesn't throw ReferenceError when the global is missing.
+  const isShared =
+    typeof SharedArrayBuffer !== 'undefined' && arr.buffer instanceof SharedArrayBuffer
+  return isShared
     ? arr.slice().buffer
     : (arr.buffer as ArrayBuffer).slice(arr.byteOffset, arr.byteOffset + arr.byteLength)
 }


### PR DESCRIPTION
## Problem

\`toBuffer()\` in \`src/crypto.ts\` throws a \`ReferenceError\` in any browser that doesn't expose \`SharedArrayBuffer\` as a global:

\`\`\`ts
function toBuffer(arr: Uint8Array): ArrayBuffer {
  return arr.buffer instanceof SharedArrayBuffer  // ← ReferenceError if SAB undefined
    ? arr.slice().buffer
    : (arr.buffer as ArrayBuffer).slice(...)
}
\`\`\`

\`instanceof\` evaluates the right-hand identifier before comparing — if the global doesn't exist, the expression throws before the check happens, rather than returning false.

This means **every caller of \`toBuffer\` breaks**: \`encrypt\`, \`decrypt\`, \`eciesEncrypt\`, \`eciesDecrypt\` — effectively every crypto-requiring operation (\`mailbox.send\`, \`mailbox.readMessages\`, \`mailbox.checkInbox\`, \`registry.sendNotification\`, \`registry.pollNotifications\`).

## Where it shows up

- **Brave** (default settings) disables \`SharedArrayBuffer\` for fingerprinting protection.
- Any page that isn't **cross-origin isolated** (COOP: same-origin + COEP: require-corp headers). Chrome and Firefox only expose SAB in that context since 2022.

So in practice, any host app running swarm-notify in a regular web page — not just Brave — hits this unless they opt into cross-origin isolation, which has side effects on embedded resources.

Observed during Nook integration testing ([GasperX93/nook#46](https://github.com/GasperX93/nook/issues/46)):

\`\`\`
[4:12:58 PM] Send failed: SharedArrayBuffer is not defined
[4:12:58 PM] Notification failed: SharedArrayBuffer is not defined
\`\`\`

## Fix

Guard the \`instanceof\` with a \`typeof\` check:

\`\`\`ts
const isShared =
  typeof SharedArrayBuffer !== 'undefined' && arr.buffer instanceof SharedArrayBuffer
return isShared
  ? arr.slice().buffer
  : (arr.buffer as ArrayBuffer).slice(...)
\`\`\`

\`typeof\` is the standard way to check for a possibly-undeclared global without throwing. When the global is missing, we fall through to the non-shared branch — which is correct (no shared buffer can exist if the global isn't defined).

## Test plan

- [ ] Reproduce original failure in Brave (no COOP/COEP). With this branch pinned, \`mailbox.send\` + \`registry.sendNotification\` should complete successfully.
- [ ] No regression on cross-origin-isolated pages where \`SharedArrayBuffer\` *is* available — the guard short-circuits only when SAB is missing.
- [ ] No regression in Node (e.g., the CLI) — Node 20+ exposes \`SharedArrayBuffer\` globally, so the behavior is unchanged.

## Related

- [swarm-notify#29](https://github.com/GasperX93/swarm-notify/pull/29) — the \`prepare\` script fix, merged earlier this week
- [swarm-notify#16](https://github.com/GasperX93/swarm-notify/issues/16) — omnibus integration review that this was discovered while closing out