### PR TITLE
Drop overlay, use ETH address as canonical identifier (#36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ SENDING A MESSAGE (Bob → Alice):
     │
     ├─ 1. identity.resolve(bee, aliceEthAddress)
     │     └─ reads feed at keccak256("swarm-identity-" + aliceEthAddress)
-    │     └─ returns: { walletPublicKey, beePublicKey, overlay }
+    │     └─ returns: { walletPublicKey, beePublicKey }
     │
     ├─ 2. crypto.deriveSharedSecret(bobPrivateKey, aliceWalletPublicKey)
     │     └─ ECDH → 32-byte shared secret (both parties derive the same one)
@@ -40,11 +40,11 @@ SENDING A MESSAGE (Bob → Alice):
     │     └─ upload to Swarm → reference hash
     │
     ├─ 5. bee.makeFeedWriter(topic, signer).upload(stamp, reference)
-    │     └─ topic = keccak256(bobOverlay + aliceOverlay + "swarm-notify")
+    │     └─ topic = keccak256(bobEthAddress + aliceEthAddress + "swarm-notify")
     │     └─ updates Bob→Alice mailbox feed
     │
     └─ 6. registry.sendNotification(provider, aliceEthAddress, payload, bobPrivateKey)
-          └─ ECIES-encrypt { sender, overlay, feedTopic } with Alice's publicKey
+          └─ ECIES-encrypt { sender } with Alice's publicKey
           └─ call notify(keccak256(aliceEthAddress), encryptedBlob) on Gnosis Chain
           └─ only needed for FIRST contact
 
@@ -58,7 +58,7 @@ RECEIVING A MESSAGE (Alice checks):
     │     └─ auto-add as contacts
     │
     ├─ 2. For each contact: mailbox.readMessages(bee, signer, contact)
-    │     └─ topic = keccak256(contactOverlay + aliceOverlay + "swarm-notify")
+    │     └─ topic = keccak256(contactEthAddress + aliceEthAddress + "swarm-notify")
     │     └─ read feed → download blob → ECDH derive secret → AES-GCM decrypt
     │     └─ returns: Message[]
     │
@@ -69,10 +69,10 @@ RECEIVING A MESSAGE (Alice checks):
 
 ```
 Identity feed:  keccak256("swarm-identity-" + ethAddress)
-Mailbox feed:   keccak256(senderOverlay + recipientOverlay + "swarm-notify")
+Mailbox feed:   keccak256(senderEthAddress + recipientEthAddress + "swarm-notify")
 ```
 
-Identity feeds are keyed by ETH address (stable across devices), not overlay (changes per Bee installation).
+Both feed types are keyed by ETH address — stable across devices and Bee installations.
 
 ### Encryption
 
@@ -105,7 +105,6 @@ These are the shared interfaces. Every module uses them.
 interface SwarmIdentity {
   walletPublicKey: string    // compressed secp256k1 (66 hex) — for ECDH encryption
   beePublicKey: string       // Bee node public key — for ACT grantee lists
-  overlay: string            // Bee overlay address — for mailbox feed topics
   ethAddress?: string        // publisher's ETH address (optional, derivable from feed)
 }
 
@@ -116,7 +115,7 @@ interface Message {
   subject: string
   body: string
   ts: number                 // unix timestamp ms
-  sender: string             // sender's overlay address
+  sender: string             // sender's ETH address
   type?: 'message' | 'drive-share'  // default: 'message'
   attachments?: Attachment[]
   // drive-share specific
@@ -139,7 +138,6 @@ interface Contact {
   nickname: string
   walletPublicKey: string    // cached from identity feed
   beePublicKey: string       // cached from identity feed
-  overlay: string            // cached from identity feed
   ensName?: string
   addedAt: number            // unix timestamp ms
 }
@@ -148,8 +146,6 @@ interface Contact {
 
 interface NotificationPayload {
   sender: string             // sender's ETH address
-  overlay: string            // sender's overlay
-  feedTopic: string          // mailbox feed topic to read
 }
 
 // ─── Crypto ──────────────────────────────────────────────────────
@@ -202,10 +198,10 @@ function feedTopic(ethAddress: string): string  // returns keccak256("swarm-iden
 
 // ─── mailbox.ts ──────────────────────────────────────────────────
 
-function send(bee: Bee, signer: string | Uint8Array, stamp: string, myPrivateKey: Uint8Array, myOverlay: string, recipient: Contact, message: Omit<Message, 'v' | 'ts' | 'sender'>): Promise<void>
-function readMessages(bee: Bee, myPrivateKey: Uint8Array, myOverlay: string, contact: Contact): Promise<Message[]>
-function checkInbox(bee: Bee, myPrivateKey: Uint8Array, myOverlay: string, contacts: Contact[]): Promise<{ contact: Contact; messages: Message[] }[]>
-function feedTopic(senderOverlay: string, recipientOverlay: string): string
+function send(bee: Bee, signer: string | Uint8Array, stamp: string, myPrivateKey: Uint8Array, myEthAddress: string, recipient: Contact, message: Omit<Message, 'v' | 'ts' | 'sender'>): Promise<void>
+function readMessages(bee: Bee, myPrivateKey: Uint8Array, myEthAddress: string, contact: Contact): Promise<Message[]>
+function checkInbox(bee: Bee, myPrivateKey: Uint8Array, myEthAddress: string, contacts: Contact[]): Promise<{ contact: Contact; messages: Message[] }[]>
+function feedTopic(senderEthAddress: string, recipientEthAddress: string): string
 
 // ─── contacts.ts ─────────────────────────────────────────────────
 // ContactStore is an in-memory class. Host apps handle persistence.
@@ -215,7 +211,7 @@ class ContactStore {
   add(ethAddress: string, nickname: string, identity: SwarmIdentity): Contact
   remove(ethAddress: string): void
   list(): Contact[]
-  update(ethAddress: string, changes: Partial<Pick<Contact, 'nickname' | 'overlay' | 'walletPublicKey' | 'beePublicKey'>>): Contact
+  update(ethAddress: string, changes: Partial<Pick<Contact, 'nickname' | 'walletPublicKey' | 'beePublicKey'>>): Contact
   export(): Contact[]
 }
 
@@ -299,7 +295,7 @@ registry.ts (depends on: crypto, NotifyProvider interface — no ethers, no Swar
 
 ## Key Design Decisions
 
-1. **ETH address as primary identifier, not overlay.** Overlay changes per Bee installation. ETH address is portable across devices.
+1. **ETH address as sole identifier.** Overlay is not used anywhere — identity, mailbox feed topics, and notifications all key on ETH address. This means the same wallet on different Bee nodes shares one inbox.
 
 2. **Two feeds per conversation.** Alice→Bob and Bob→Alice are separate feeds (each owned by the sender). Merge by timestamp to get full conversation.
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -83,7 +83,6 @@ Before others can message you, publish your public keys to a discoverable Swarm 
 const myIdentity = {
   walletPublicKey: myCompressedPublicKey,  // 66 hex chars, compressed secp256k1
   beePublicKey: beeNodePublicKey,          // from bee.getNodeAddresses()
-  overlay: myOverlayAddress,               // from bee.getNodeAddresses()
   ethAddress: myEthAddress,                // your wallet address
 }
 
@@ -93,6 +92,8 @@ await identity.publish(bee, myPrivateKeyHex, myPostageStampId, myIdentity)
 This writes a small JSON document to a deterministic feed at `keccak256("swarm-identity-" + ethAddress)`. Anyone who knows your ETH address can now look you up.
 
 This is a one-time operation. Only re-publish if your keys change (e.g., new Bee node).
+
+**Multi-device:** ETH address is cross-device-stable — the same wallet on different machines shares one inbox. Identity and mailbox feeds are keyed by ETH address, not by Bee overlay, so switching Bee nodes does not change your address or break existing conversations.
 
 ## 3. Discover someone
 
@@ -108,7 +109,6 @@ if (!alice) {
 
 // alice.walletPublicKey — for ECDH encryption
 // alice.beePublicKey    — for ACT grantee lists
-// alice.overlay         — for mailbox feed topics
 ```
 
 **ENS support:** Swarm Notify takes ETH addresses only. If your app supports ENS, resolve the name first:
@@ -160,7 +160,7 @@ await mailbox.send(
   myPrivateKeyHex,       // feed signing key
   myPostageStampId,
   myEncryptionPrivKey,   // Uint8Array — for ECDH shared secret
-  myOverlayAddress,
+  myEthAddress,
   aliceContact,
   {
     subject: 'Hello from my app',
@@ -183,7 +183,7 @@ When your app shares an encrypted drive, notify the recipient:
 
 ```typescript
 await mailbox.send(
-  bee, signer, stamp, myPrivateKey, myOverlay, aliceContact,
+  bee, signer, stamp, myPrivateKey, myEthAddress, aliceContact,
   {
     subject: 'Shared: Project files',
     body: 'I shared a drive with you.',
@@ -203,7 +203,7 @@ Read messages from a specific contact:
 const messages = await mailbox.readMessages(
   bee,
   myEncryptionPrivKey,
-  myOverlayAddress,
+  myEthAddress,
   aliceContact,
 )
 
@@ -224,7 +224,7 @@ Check inbox across all contacts:
 const inbox = await mailbox.checkInbox(
   bee,
   myEncryptionPrivKey,
-  myOverlayAddress,
+  myEthAddress,
   contacts.list(),
 )
 
@@ -249,8 +249,6 @@ await registry.sendNotification(
   aliceContact.ethAddress,
   {
     sender: myEthAddress,
-    overlay: myOverlayAddress,
-    feedTopic: mailbox.feedTopic(myOverlayAddress, aliceContact.overlay),
   },
 )
 ```
@@ -299,7 +297,6 @@ const contacts = new ContactStore()
 await identity.publish(bee, bobSignerKey, bobStamp, {
   walletPublicKey: bobPublicKeyHex,
   beePublicKey: bobBeePublicKey,
-  overlay: bobOverlay,
   ethAddress: bobEthAddress,
 })
 
@@ -308,7 +305,7 @@ const alice = await identity.resolve(bee, aliceEthAddress)
 const aliceContact = contacts.add(alice.ethAddress!, 'Alice', alice)
 
 // 3. Send message
-await mailbox.send(bee, bobSignerKey, bobStamp, bobPrivateKey, bobOverlay, aliceContact, {
+await mailbox.send(bee, bobSignerKey, bobStamp, bobPrivateKey, bobEthAddress, aliceContact, {
   subject: 'Hey Alice',
   body: 'Check out this shared drive!',
   type: 'drive-share',
@@ -321,7 +318,7 @@ await mailbox.send(bee, bobSignerKey, bobStamp, bobPrivateKey, bobOverlay, alice
 await registry.sendNotification(
   bobNotifyProvider, REGISTRY,
   hexToBytes(alice.walletPublicKey), alice.ethAddress!,
-  { sender: bobEthAddress, overlay: bobOverlay, feedTopic: mailbox.feedTopic(bobOverlay, alice.overlay) },
+  { sender: bobEthAddress },
 )
 
 // ── Alice's side ─────────────────────────────────────────────
@@ -338,7 +335,7 @@ for (const { payload } of notifications) {
 }
 
 // 7. Alice reads her inbox
-const inbox = await mailbox.checkInbox(bee, alicePrivateKey, aliceOverlay, contacts.list())
+const inbox = await mailbox.checkInbox(bee, alicePrivateKey, aliceEthAddress, contacts.list())
 for (const { contact, messages } of inbox) {
   for (const msg of messages) {
     console.log(`${contact.nickname}: ${msg.subject} — ${msg.body}`)

--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -96,23 +96,11 @@ const identityCmd = program.command('identity').description('Publish and resolve
 
 identityCmd
   .command('publish')
-  .description('Publish your identity (public keys + overlay) to a Swarm feed. One-time setup — others can then discover you by ETH address.')
-  .option('--overlay <hex>', 'Override overlay address (default: fetched from Bee node)')
-  .action(async (opts) => {
+  .description('Publish your identity (public keys) to a Swarm feed. One-time setup — others can then discover you by ETH address.')
+  .action(async () => {
     const privKey = getPrivateKey()
     const stamp = requireStamp()
     const bee = new Bee(BEE_URL)
-
-    let overlay = opts.overlay
-    if (!overlay) {
-      try {
-        const addresses = await bee.getNodeAddresses()
-        overlay = String(addresses.overlay)
-      } catch (e) {
-        console.error('Could not fetch overlay from Bee node. Pass --overlay or check BEE_URL.')
-        process.exit(1)
-      }
-    }
 
     const ethAddress = getEthAddress(privKey)
     const pubKeyHex = getPublicKeyHex(privKey)
@@ -121,18 +109,16 @@ identityCmd
     await identity.publish(bee, getPrivateKeyHex(privKey), stamp, {
       walletPublicKey: pubKeyHex,
       beePublicKey: pubKeyHex, // Using wallet key as bee key for CLI simplicity
-      overlay,
       ethAddress,
     })
 
     console.log(`Identity published for ${ethAddress}`)
     console.log(`  walletPublicKey: ${pubKeyHex}`)
-    console.log(`  overlay: ${overlay}`)
   })
 
 identityCmd
   .command('resolve')
-  .description('Look up someone\'s identity (public keys + overlay) from their Swarm feed')
+  .description('Look up someone\'s identity (public keys) from their Swarm feed')
   .argument('<ethAddress>', 'ETH address to look up')
   .action(async (ethAddress: string) => {
     const bee = new Bee(BEE_URL)
@@ -153,28 +139,26 @@ const contactsCmd = program.command('contacts').description('Manage local addres
 
 contactsCmd
   .command('add')
-  .description('Add a contact — resolves their identity from Swarm, or pass keys manually with --wallet-pub and --overlay')
+  .description('Add a contact — resolves their identity from Swarm, or pass keys manually with --wallet-pub')
   .argument('<ethAddress>', 'ETH address')
   .argument('<nickname>', 'Display name')
   .option('--wallet-pub <hex>', 'Manually provide wallet public key (skip identity resolve)')
   .option('--bee-pub <hex>', 'Manually provide bee public key')
-  .option('--overlay <hex>', 'Manually provide overlay address')
   .action(async (ethAddress: string, nickname: string, opts) => {
     let swarmId
 
-    if (opts.walletPub && opts.overlay) {
+    if (opts.walletPub) {
       // Manual mode — no Bee node needed
       swarmId = {
         walletPublicKey: opts.walletPub,
         beePublicKey: opts.beePub || opts.walletPub,
-        overlay: opts.overlay,
       }
     } else {
       // Resolve from Swarm
       const bee = new Bee(BEE_URL)
       const resolved = await identity.resolve(bee, ethAddress)
       if (!resolved) {
-        console.error(`No identity found for ${ethAddress}. Use --wallet-pub and --overlay to add manually.`)
+        console.error(`No identity found for ${ethAddress}. Use --wallet-pub to add manually.`)
         process.exit(1)
       }
       swarmId = resolved
@@ -207,7 +191,7 @@ contactsCmd
       return
     }
     for (const c of all) {
-      console.log(`  ${c.nickname} — ${c.ethAddress} (overlay: ${c.overlay.slice(0, 16)}...)`)
+      console.log(`  ${c.nickname} — ${c.ethAddress}`)
     }
   })
 
@@ -227,14 +211,6 @@ mailboxCmd
     const bee = new Bee(BEE_URL)
 
     const myAddress = getEthAddress(privKey)
-    let myOverlay: string
-    try {
-      const addresses = await bee.getNodeAddresses()
-      myOverlay = String(addresses.overlay)
-    } catch {
-      console.error('Could not fetch overlay from Bee node. Check BEE_URL.')
-      process.exit(1)
-    }
 
     const contact = loadContacts().list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
     if (!contact) {
@@ -242,7 +218,7 @@ mailboxCmd
       process.exit(1)
     }
 
-    await mailbox.send(bee, getPrivateKeyHex(privKey), stamp, privKey, myOverlay, contact, {
+    await mailbox.send(bee, getPrivateKeyHex(privKey), stamp, privKey, myAddress, contact, {
       subject: opts.subject,
       body: opts.body,
     })
@@ -258,14 +234,7 @@ mailboxCmd
     const privKey = getPrivateKey()
     const bee = new Bee(BEE_URL)
 
-    let myOverlay: string
-    try {
-      const addresses = await bee.getNodeAddresses()
-      myOverlay = String(addresses.overlay)
-    } catch {
-      console.error('Could not fetch overlay from Bee node. Check BEE_URL.')
-      process.exit(1)
-    }
+    const myAddress = getEthAddress(privKey)
 
     const contact = loadContacts().list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
     if (!contact) {
@@ -273,7 +242,7 @@ mailboxCmd
       process.exit(1)
     }
 
-    const messages = await mailbox.readMessages(bee, privKey, myOverlay, contact)
+    const messages = await mailbox.readMessages(bee, privKey, myAddress, contact)
 
     if (messages.length === 0) {
       console.log(`No messages from ${contact.nickname}.`)
@@ -294,14 +263,7 @@ mailboxCmd
     const privKey = getPrivateKey()
     const bee = new Bee(BEE_URL)
 
-    let myOverlay: string
-    try {
-      const addresses = await bee.getNodeAddresses()
-      myOverlay = String(addresses.overlay)
-    } catch {
-      console.error('Could not fetch overlay from Bee node. Check BEE_URL.')
-      process.exit(1)
-    }
+    const myAddress = getEthAddress(privKey)
 
     const allContacts = loadContacts().list()
     if (allContacts.length === 0) {
@@ -309,7 +271,7 @@ mailboxCmd
       return
     }
 
-    const inbox = await mailbox.checkInbox(bee, privKey, myOverlay, allContacts)
+    const inbox = await mailbox.checkInbox(bee, privKey, myAddress, allContacts)
 
     if (inbox.length === 0) {
       console.log('No new messages.')
@@ -338,16 +300,6 @@ registryCmd
     const privKey = getPrivateKey()
     const provider = createSigningProvider(GNOSIS_RPC_URL, '0x' + bytesToHex(privKey))
 
-    let myOverlay: string
-    try {
-      const bee = new Bee(BEE_URL)
-      const addresses = await bee.getNodeAddresses()
-      myOverlay = String(addresses.overlay)
-    } catch {
-      console.error('Could not fetch overlay from Bee node. Check BEE_URL.')
-      process.exit(1)
-    }
-
     const contact = loadContacts().list().find((c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase())
     if (!contact) {
       console.error(`Contact not found: ${ethAddress}. Add them first.`)
@@ -355,7 +307,6 @@ registryCmd
     }
 
     const myAddress = getEthAddress(privKey)
-    const feedTopic = mailbox.feedTopic(myOverlay, contact.overlay)
     const recipientPubKey = hexToBytes(contact.walletPublicKey)
 
     const txHash = await registry.sendNotification(
@@ -363,7 +314,7 @@ registryCmd
       CONTRACT_ADDRESS,
       recipientPubKey,
       contact.ethAddress,
-      { sender: myAddress, overlay: myOverlay, feedTopic },
+      { sender: myAddress },
     )
 
     console.log(`Notification sent to ${contact.nickname}`)
@@ -392,9 +343,7 @@ registryCmd
     console.log(`Found ${notifications.length} notification(s):`)
     for (const n of notifications) {
       console.log(`\n  Block ${n.blockNumber}:`)
-      console.log(`    sender:    ${n.payload.sender}`)
-      console.log(`    overlay:   ${n.payload.overlay}`)
-      console.log(`    feedTopic: ${n.payload.feedTopic}`)
+      console.log(`    sender: ${n.payload.sender}`)
     }
   })
 

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -197,18 +197,18 @@
         </thead>
         <tbody>
           <tr>
-            <td><strong>Identity</strong><br/><code>{ walletPublicKey, beePublicKey, overlay }</code></td>
+            <td><strong>Identity</strong><br/><code>{ walletPublicKey, beePublicKey }</code></td>
             <td><span class="net-tag swarm">Swarm</span></td>
             <td>None — plaintext</td>
             <td>Anyone who knows your ETH address</td>
-            <td>Your public keys and overlay. Public by design — same model as PGP public keys.</td>
+            <td>Your public keys. Public by design — same model as PGP public keys.</td>
           </tr>
           <tr>
             <td><strong>Messages</strong><br/><code>[nonce (12B) | AES-256-GCM ciphertext]</code></td>
             <td><span class="net-tag swarm">Swarm</span></td>
             <td>ECDH + AES-256-GCM</td>
             <td>Only sender + recipient</td>
-            <td>That a feed exists between two overlays, and the encrypted blob size. Content is unreadable.</td>
+            <td>That a feed exists and the encrypted blob size. Content is unreadable.</td>
           </tr>
           <tr>
             <td><strong>Notifications</strong><br/><code>Notification(keccak256(addr), eciesBlob)</code></td>
@@ -246,7 +246,7 @@
           <div id="alice-publish-result" class="result"></div>
         </div>
         <div class="card-info">
-          <strong>What:</strong> Writes Alice's public keys (for encryption) and overlay address (for feed routing)
+          <strong>What:</strong> Writes Alice's public keys (for encryption)
           to a Swarm feed. The feed is at a deterministic topic:
           <code>keccak256("swarm-identity-" + ethAddress)</code>.
           <br/><br/>
@@ -254,7 +254,7 @@
           This is the foundation — without published keys, nobody can encrypt messages to you.
           <br/><br/>
           <strong>Data published (plaintext):</strong>
-          <code>{ walletPublicKey: "02ab...", beePublicKey: "04cd...", overlay: "ff12..." }</code>
+          <code>{ walletPublicKey: "02ab...", beePublicKey: "04cd..." }</code>
           <br/>Written to Swarm feed at topic <code>keccak256("swarm-identity-" + ethAddress)</code>.
           <br/><br/>
           <strong>Privacy:</strong> <strong>Public by design</strong> — anyone who knows your ETH address can read this.
@@ -276,7 +276,7 @@
         </div>
         <div class="card-info">
           <strong>What:</strong> Alice reads Bob's identity feed from Swarm using his ETH address.
-          She now has Bob's public key and overlay address — everything needed to send him encrypted messages.
+          She now has Bob's public key — everything needed to send him encrypted messages.
           <br/><br/>
           <strong>How does Alice know Bob's address?</strong> The same way you know someone's email:
           it was shared out-of-band — in a chat, on a website, via QR code, or in a contact directory.
@@ -313,10 +313,10 @@
           <br/><br/>
           <strong>Data published (encrypted):</strong>
           <code>[nonce (12 bytes) | AES-256-GCM ciphertext]</code>
-          <br/>Written to Swarm feed at topic <code>keccak256(aliceOverlay + bobOverlay + "swarm-notify")</code>.
+          <br/>Written to Swarm feed at topic <code>keccak256(aliceEthAddress + bobEthAddress + "swarm-notify")</code>.
           <br/><br/>
           <strong>Privacy:</strong> Only Alice and Bob can decrypt the content. An observer can see that a feed
-          exists between two overlays and the blob size, but <strong>cannot read the messages</strong>.
+          exists and the blob size, but <strong>cannot read the messages</strong>.
           The encryption key is never transmitted — both parties derive it independently.
         </div>
       </div>
@@ -343,7 +343,7 @@
           <br/><br/>
           <strong>Data published (on-chain, encrypted):</strong>
           <code>Notification(keccak256(bobAddress), eciesEncryptedBlob)</code>
-          <br/>The encrypted blob contains: <code>{ sender: "0xAlice...", overlay: "ff12...", feedTopic: "a3b2..." }</code>
+          <br/>The encrypted blob contains: <code>{ sender: "0xAlice..." }</code>
           <br/><br/>
           <strong>Privacy:</strong> Only Bob can decrypt the payload (ECIES with his private key).
           An observer on Gnosis Chain can see that <em>someone</em> sent a notification to
@@ -474,8 +474,8 @@
           <br/><br/>
           <strong>How:</strong> Calls <code>eth_getLogs</code> with topic filter
           <code>keccak256(bobAddress)</code>. For each log, tries to <strong>ECIES-decrypt</strong>
-          the payload with Bob's private key. Successful decryption reveals the sender's address,
-          overlay, and feed topic. Failed decryption = spam or not for Bob, silently discarded.
+          the payload with Bob's private key. Successful decryption reveals the sender's ETH address.
+          The recipient derives the feed topic from both ETH addresses. Failed decryption = spam or not for Bob, silently discarded.
           <br/><br/>
           <strong>When is this needed?</strong> Only to discover <em>strangers</em> who contacted you.
           If Bob already knows Alice (from step 3), he can read her feed directly without polling.

--- a/examples/web/src/main.ts
+++ b/examples/web/src/main.ts
@@ -152,12 +152,6 @@ $('btn-init').addEventListener('click', async () => {
   alice.otherPanel = bob
   bob.otherPanel = alice
 
-  // Fetch overlay from Bee node (shared — same node)
-  await alice.fetchOverlay(bee)
-  // Bob uses a synthetic overlay (different identity, same node)
-  bob.overlay = bytesToHex(secp.getPublicKey(bobPrivKey, true)).slice(0, 32)
-  logBob(`Overlay (synthetic): <code>${short(bob.overlay!)}</code>`)
-
   // Display identity info with full addresses
   $('alice-eth').textContent = alice.ethAddress
   $('alice-pub').textContent = short(alice.publicKeyHex, 12)
@@ -210,7 +204,7 @@ $('alice-resolve').addEventListener('click', () =>
     if (resolved) {
       setResult(
         'alice-resolve-result',
-        `Found Bob!<br/>PubKey: <code>${short(resolved.walletPublicKey, 12)}</code><br/>Overlay: <code>${short(resolved.overlay)}</code>`,
+        `Found Bob!<br/>PubKey: <code>${short(resolved.walletPublicKey, 12)}</code>`,
         'success',
       )
       enableButtons('alice-send', 'alice-notify', 'alice-inbox')
@@ -227,7 +221,7 @@ $('bob-resolve').addEventListener('click', () =>
     if (resolved) {
       setResult(
         'bob-resolve-result',
-        `Found Alice!<br/>PubKey: <code>${short(resolved.walletPublicKey, 12)}</code><br/>Overlay: <code>${short(resolved.overlay)}</code>`,
+        `Found Alice!<br/>PubKey: <code>${short(resolved.walletPublicKey, 12)}</code>`,
         'success',
       )
       enableButtons('bob-send', 'bob-read', 'bob-poll')
@@ -320,7 +314,7 @@ $('bob-poll').addEventListener('click', () =>
       setResult('bob-poll-result', 'No notifications found.', 'info')
     } else {
       const lines = notifications.map(
-        (n) => `Sender: <code>${short(n.payload.sender)}</code><br/>Overlay: <code>${short(n.payload.overlay)}</code><br/>Block: ${n.blockNumber}`,
+        (n) => `Sender: <code>${short(n.payload.sender)}</code><br/>Block: ${n.blockNumber}`,
       )
       setResult('bob-poll-result', `Found ${notifications.length}:<br/><br/>${lines.join('<br/><br/>')}`, 'success')
     }

--- a/examples/web/src/panel.ts
+++ b/examples/web/src/panel.ts
@@ -34,7 +34,6 @@ export class Panel {
   readonly publicKey: Uint8Array
   readonly publicKeyHex: string
   readonly ethAddress: string
-  overlay: string | null = null
   otherPanel: Panel | null = null
   contact: Contact | null = null // the other party
 
@@ -49,23 +48,12 @@ export class Panel {
     this.logger = logger
   }
 
-  /** Fetch overlay address from Bee node. */
-  async fetchOverlay(bee: Bee): Promise<string> {
-    const addresses = await bee.getNodeAddresses()
-    this.overlay = String(addresses.overlay)
-    this.logger(`Overlay fetched: <code>${short(this.overlay)}</code>`)
-    return this.overlay
-  }
-
   /** Publish identity to Swarm feed. */
   async publishIdentity(bee: Bee, stamp: string): Promise<void> {
-    if (!this.overlay) throw new Error('Overlay not fetched')
-
     const signerHex = '0x' + bytesToHex(this.privateKey)
     const swarmId: SwarmIdentity = {
       walletPublicKey: this.publicKeyHex,
       beePublicKey: this.publicKeyHex,
-      overlay: this.overlay,
       ethAddress: this.ethAddress,
     }
 
@@ -96,25 +84,24 @@ export class Panel {
       nickname: this.otherPanel.name,
       walletPublicKey: resolved.walletPublicKey,
       beePublicKey: resolved.beePublicKey,
-      overlay: resolved.overlay,
       addedAt: Date.now(),
     }
 
-    this.logger(`Resolved ${this.otherPanel.name}: pubKey=<code>${short(resolved.walletPublicKey)}</code>, overlay=<code>${short(resolved.overlay)}</code>`)
+    this.logger(`Resolved ${this.otherPanel.name}: pubKey=<code>${short(resolved.walletPublicKey)}</code>`)
     return resolved
   }
 
   /** Send an encrypted message to the other party. */
   async sendMessage(bee: Bee, stamp: string, subject: string, body: string): Promise<void> {
-    if (!this.contact || !this.overlay) throw new Error('Not ready')
+    if (!this.contact) throw new Error('Not ready')
 
     const signerHex = '0x' + bytesToHex(this.privateKey)
-    const feedTopic = mailbox.feedTopic(this.overlay, this.contact.overlay)
+    const feedTopic = mailbox.feedTopic(this.ethAddress, this.contact.ethAddress)
     this.logger(`Mailbox feed topic: <code>${short(feedTopic)}</code>`)
     this.logger(`ECDH: deriving shared secret from ${this.name}'s privKey + ${this.contact.nickname}'s pubKey`)
     this.logger(`AES-256-GCM encrypting message...`)
 
-    await mailbox.send(bee, signerHex, stamp, this.privateKey, this.overlay, this.contact, {
+    await mailbox.send(bee, signerHex, stamp, this.privateKey, this.ethAddress, this.contact, {
       subject,
       body,
     })
@@ -124,12 +111,12 @@ export class Panel {
 
   /** Read messages from the other party's mailbox feed. */
   async readMessages(bee: Bee): Promise<Message[]> {
-    if (!this.contact || !this.overlay) throw new Error('Not ready')
+    if (!this.contact) throw new Error('Not ready')
 
     this.logger(`Reading ${this.contact.nickname}'s mailbox feed...`)
     this.logger(`ECDH: deriving shared secret from ${this.name}'s privKey + ${this.contact.nickname}'s pubKey`)
 
-    const messages = await mailbox.readMessages(bee, this.privateKey, this.overlay, this.contact)
+    const messages = await mailbox.readMessages(bee, this.privateKey, this.ethAddress, this.contact)
 
     if (messages.length === 0) {
       this.logger(`No messages from ${this.contact.nickname}`)
@@ -145,15 +132,12 @@ export class Panel {
 
   /** Send an on-chain notification to the other party. */
   async sendNotification(provider: NotifyProvider, contractAddress: string): Promise<string> {
-    if (!this.contact || !this.overlay || !this.otherPanel) throw new Error('Not ready')
+    if (!this.contact || !this.otherPanel) throw new Error('Not ready')
 
     const recipientPubKey = hexToBytes(this.contact.walletPublicKey)
-    const feedTopic = mailbox.feedTopic(this.overlay, this.contact.overlay)
 
     const payload: NotificationPayload = {
       sender: this.ethAddress,
-      overlay: this.overlay,
-      feedTopic,
     }
 
     this.logger(`ECIES-encrypting notification payload with ${this.contact.nickname}'s public key`)

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -40,7 +40,6 @@ export class ContactStore {
       nickname,
       walletPublicKey: identity.walletPublicKey,
       beePublicKey: identity.beePublicKey,
-      overlay: identity.overlay,
       addedAt: Date.now(),
     }
     this.contacts.push(contact)
@@ -69,7 +68,7 @@ export class ContactStore {
    */
   update(
     ethAddress: string,
-    changes: Partial<Pick<Contact, 'nickname' | 'overlay' | 'walletPublicKey' | 'beePublicKey'>>,
+    changes: Partial<Pick<Contact, 'nickname' | 'walletPublicKey' | 'beePublicKey'>>,
   ): Contact {
     const index = this.contacts.findIndex(
       (c) => c.ethAddress.toLowerCase() === ethAddress.toLowerCase(),

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -33,7 +33,6 @@ export async function publish(
     JSON.stringify({
       walletPublicKey: identity.walletPublicKey,
       beePublicKey: identity.beePublicKey,
-      overlay: identity.overlay,
     }),
   )
 
@@ -62,14 +61,13 @@ export async function resolve(
     const data = JSON.parse(text)
 
     // Validate required fields
-    if (!data.walletPublicKey || !data.beePublicKey || !data.overlay) {
+    if (!data.walletPublicKey || !data.beePublicKey) {
       return null
     }
 
     return {
       walletPublicKey: data.walletPublicKey,
       beePublicKey: data.beePublicKey,
-      overlay: data.overlay,
       ethAddress: ethAddress.toLowerCase(),
     }
   } catch {

--- a/src/mailbox.ts
+++ b/src/mailbox.ts
@@ -8,10 +8,13 @@ const FEED_SUFFIX = 'swarm-notify'
 
 /**
  * Compute the deterministic mailbox feed topic for a sender-recipient pair.
- * Topic: keccak256(senderOverlay + recipientOverlay + "swarm-notify")
+ * Topic: keccak256(senderEthAddress + recipientEthAddress + "swarm-notify")
+ *
+ * Uses ETH addresses (not overlays) so feed topics are stable across devices.
+ * Same wallet on different Bee nodes = same feed topics = same inbox.
  */
-export function feedTopic(senderOverlay: string, recipientOverlay: string): string {
-  const input = new TextEncoder().encode(senderOverlay.toLowerCase() + recipientOverlay.toLowerCase() + FEED_SUFFIX)
+export function feedTopic(senderEthAddress: string, recipientEthAddress: string): string {
+  const input = new TextEncoder().encode(senderEthAddress.toLowerCase() + recipientEthAddress.toLowerCase() + FEED_SUFFIX)
   return bytesToHex(keccak_256(input))
 }
 
@@ -60,7 +63,7 @@ export async function send(
   signer: string | Uint8Array,
   stamp: string,
   myPrivateKey: Uint8Array,
-  myOverlay: string,
+  myEthAddress: string,
   recipient: Contact,
   message: Omit<Message, 'v' | 'ts' | 'sender'>,
 ): Promise<void> {
@@ -68,8 +71,8 @@ export async function send(
   const recipientPubKeyBytes = hexToBytes(recipient.walletPublicKey)
   const sharedSecret = deriveSharedSecret(myPrivateKey, recipientPubKeyBytes)
 
-  // Compute feed topic (my overlay → their overlay)
-  const topic = feedTopic(myOverlay, recipient.overlay)
+  // Compute feed topic (my ethAddress → their ethAddress)
+  const topic = feedTopic(myEthAddress, recipient.ethAddress)
 
   // Get the writer's ETH address for reading existing messages
   const writer = bee.makeFeedWriter(topic, signer)
@@ -83,7 +86,7 @@ export async function send(
     v: 1,
     ...message,
     ts: Date.now(),
-    sender: myOverlay,
+    sender: myEthAddress,
   }
   existing.push(fullMessage)
 
@@ -108,7 +111,7 @@ export async function send(
 export async function readMessages(
   bee: Bee,
   myPrivateKey: Uint8Array,
-  myOverlay: string,
+  myEthAddress: string,
   contact: Contact,
 ): Promise<Message[]> {
   // Derive shared secret
@@ -116,7 +119,7 @@ export async function readMessages(
   const sharedSecret = deriveSharedSecret(myPrivateKey, contactPubKeyBytes)
 
   // Topic: contact→me (contact is sender)
-  const topic = feedTopic(contact.overlay, myOverlay)
+  const topic = feedTopic(contact.ethAddress, myEthAddress)
 
   // The feed owner is the contact's ETH address
   return readFeedMessages(bee, topic, contact.ethAddress, sharedSecret)
@@ -128,13 +131,13 @@ export async function readMessages(
 export async function checkInbox(
   bee: Bee,
   myPrivateKey: Uint8Array,
-  myOverlay: string,
+  myEthAddress: string,
   contacts: Contact[],
 ): Promise<{ contact: Contact; messages: Message[] }[]> {
   const results = await Promise.allSettled(
     contacts.map(async (contact) => ({
       contact,
-      messages: await readMessages(bee, myPrivateKey, myOverlay, contact),
+      messages: await readMessages(bee, myPrivateKey, myEthAddress, contact),
     })),
   )
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,6 @@ export interface SwarmIdentity {
   walletPublicKey: string
   /** Bee node public key — used for ACT grantee lists */
   beePublicKey: string
-  /** Bee overlay address — used for mailbox feed topic computation */
-  overlay: string
   /** Publisher's ETH address (optional, derivable from feed owner) */
   ethAddress?: string
 }
@@ -24,7 +22,7 @@ export interface Message {
   body: string
   /** Unix timestamp in milliseconds */
   ts: number
-  /** Sender's overlay address */
+  /** Sender's ETH address */
   sender: string
   /** Message type — default: 'message' */
   type?: 'message' | 'drive-share'
@@ -62,8 +60,6 @@ export interface Contact {
   walletPublicKey: string
   /** Cached from identity feed — Bee node public key for ACT */
   beePublicKey: string
-  /** Cached from identity feed — Bee overlay address for feed topics */
-  overlay: string
   /** ENS name if known */
   ensName?: string
   /** When this contact was added (unix timestamp ms) */
@@ -72,14 +68,14 @@ export interface Contact {
 
 // ─── Notifications ───────────────────────────────────────────────
 
-/** Payload sent via the on-chain notification registry (ECIES-encrypted). */
+/**
+ * Payload sent via the on-chain notification registry (ECIES-encrypted).
+ * Contains only the sender's ETH address — the recipient derives the
+ * mailbox feed topic from feedTopic(senderEthAddr, recipientEthAddr).
+ */
 export interface NotificationPayload {
   /** Sender's ETH address */
   sender: string
-  /** Sender's Bee overlay address */
-  overlay: string
-  /** Mailbox feed topic to read messages from */
-  feedTopic: string
 }
 
 // ─── Crypto ──────────────────────────────────────────────────────

--- a/test/contacts.test.ts
+++ b/test/contacts.test.ts
@@ -4,7 +4,6 @@ import { ContactStore } from '../src/contacts'
 const mockIdentity = {
   walletPublicKey: '02' + 'ab'.repeat(32),
   beePublicKey: '04' + 'cd'.repeat(32),
-  overlay: 'ff'.repeat(32),
 }
 
 let store: ContactStore
@@ -21,7 +20,6 @@ describe('add', () => {
     expect(contact.nickname).toBe('Alice')
     expect(contact.walletPublicKey).toBe(mockIdentity.walletPublicKey)
     expect(contact.beePublicKey).toBe(mockIdentity.beePublicKey)
-    expect(contact.overlay).toBe(mockIdentity.overlay)
     expect(contact.addedAt).toBeGreaterThan(0)
   })
 
@@ -83,17 +81,6 @@ describe('update', () => {
 
     expect(updated.nickname).toBe('Alice Updated')
     expect(store.list()[0].nickname).toBe('Alice Updated')
-  })
-
-  it('updates overlay (key refresh)', () => {
-    store.add('0x1111111111111111111111111111111111111111', 'Alice', mockIdentity)
-
-    const newOverlay = 'aa'.repeat(32)
-    const updated = store.update('0x1111111111111111111111111111111111111111', {
-      overlay: newOverlay,
-    })
-
-    expect(updated.overlay).toBe(newOverlay)
   })
 
   it('throws if contact not found', () => {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -14,7 +14,6 @@ import { describe, it, expect, beforeAll } from 'vitest'
 import { Bee } from '@ethersphere/bee-js'
 import * as secp from '@noble/secp256k1'
 import { bytesToHex } from '@noble/hashes/utils'
-import { keccak_256 } from '@noble/hashes/sha3'
 
 import * as identity from '../src/identity'
 import * as mailbox from '../src/mailbox'
@@ -86,13 +85,10 @@ let stamp: string
 let privateKey: Uint8Array
 let ethAddress: string
 let publicKeyHex: string
-let overlay: string
-
 // Two test identities — Alice (from DEPLOYER_PRIVATE_KEY) and Bob (generated)
 let bobPrivateKey: Uint8Array
 let bobPublicKeyHex: string
 let bobEthAddress: string
-let bobOverlay: string
 
 beforeAll(async () => {
   // Validate environment
@@ -121,15 +117,10 @@ beforeAll(async () => {
   ethAddress = getEthAddress(privateKey)
   publicKeyHex = bytesToHex(secp.getPublicKey(privateKey, true))
 
-  // Get overlay from Bee node
-  const addresses = await bee.getNodeAddresses()
-  overlay = String(addresses.overlay)
-
   // Bob's keys (generated)
   bobPrivateKey = secp.utils.randomPrivateKey()
   bobPublicKeyHex = bytesToHex(secp.getPublicKey(bobPrivateKey, true))
   bobEthAddress = getEthAddress(bobPrivateKey)
-  bobOverlay = bytesToHex(keccak_256(secp.getPublicKey(bobPrivateKey, true))).slice(0, 32)
 
   console.log('E2E test config:')
   console.log(`  Bee:      ${BEE_URL}`)
@@ -146,7 +137,6 @@ describe('identity: real Bee node', () => {
     const swarmIdentity = {
       walletPublicKey: publicKeyHex,
       beePublicKey: publicKeyHex,
-      overlay,
       ethAddress,
     }
 
@@ -158,7 +148,6 @@ describe('identity: real Bee node', () => {
 
     expect(resolved).not.toBeNull()
     expect(resolved!.walletPublicKey).toBe(publicKeyHex)
-    expect(resolved!.overlay).toBe(overlay)
   }, 30000)
 
   it('returns null for non-existent identity', async () => {
@@ -178,13 +167,12 @@ describe('mailbox: real Bee node', () => {
       nickname: 'Bob',
       walletPublicKey: bobPublicKeyHex,
       beePublicKey: bobPublicKeyHex,
-      overlay: bobOverlay,
       addedAt: Date.now(),
     }
 
     // Alice sends a message to Bob (signer = private key hex)
     const testSubject = `E2E test ${Date.now()}`
-    await mailbox.send(bee, PRIVATE_KEY_HEX, stamp, privateKey, overlay, bobContact, {
+    await mailbox.send(bee, PRIVATE_KEY_HEX, stamp, privateKey, ethAddress, bobContact, {
       subject: testSubject,
       body: 'End-to-end test message via real Bee node',
     })
@@ -195,10 +183,9 @@ describe('mailbox: real Bee node', () => {
       nickname: 'Alice',
       walletPublicKey: publicKeyHex,
       beePublicKey: publicKeyHex,
-      overlay,
       addedAt: Date.now(),
     }
-    const messages = await mailbox.readMessages(bee, bobPrivateKey, bobOverlay, aliceContact)
+    const messages = await mailbox.readMessages(bee, bobPrivateKey, bobEthAddress, aliceContact)
 
     expect(messages).toHaveLength(1)
     expect(messages[0].subject).toBe(testSubject)
@@ -217,8 +204,6 @@ describe('registry: real Gnosis Chain', () => {
 
     const payload: NotificationPayload = {
       sender: ethAddress,
-      overlay,
-      feedTopic: mailbox.feedTopic(overlay, bobOverlay),
     }
 
     const txHash = await registry.sendNotification(
@@ -259,8 +244,6 @@ describe('registry: real Gnosis Chain', () => {
     // Find our notification
     const ours = notifications.find((n) => n.payload.sender === ethAddress)
     expect(ours).toBeDefined()
-    expect(ours!.payload.overlay).toBe(overlay)
-    expect(ours!.payload.feedTopic).toBe(mailbox.feedTopic(overlay, bobOverlay))
     expect(ours!.blockNumber).toBe(notificationBlockNumber)
   }, 30000)
 })
@@ -275,13 +258,11 @@ describe('full E2E flow: identity → message → notification → discovery', (
     const charliePrivateKey = secp.utils.randomPrivateKey()
     const charliePublicKeyHex = bytesToHex(secp.getPublicKey(charliePrivateKey, true))
     const charlieEthAddress = getEthAddress(charliePrivateKey)
-    const charlieOverlay = bytesToHex(keccak_256(secp.getPublicKey(charliePrivateKey, true))).slice(0, 32)
 
     // 1. Ensure Alice's identity is published
     await identity.publish(bee, PRIVATE_KEY_HEX, stamp, {
       walletPublicKey: publicKeyHex,
       beePublicKey: publicKeyHex,
-      overlay,
       ethAddress,
     })
     const aliceId = await identity.resolve(bee, ethAddress)
@@ -293,24 +274,22 @@ describe('full E2E flow: identity → message → notification → discovery', (
       nickname: 'Charlie',
       walletPublicKey: charliePublicKeyHex,
       beePublicKey: charliePublicKeyHex,
-      overlay: charlieOverlay,
       addedAt: Date.now(),
     }
 
     const testSubject = `Full flow ${Date.now()}`
-    await mailbox.send(bee, PRIVATE_KEY_HEX, stamp, privateKey, overlay, charlieContact, {
+    await mailbox.send(bee, PRIVATE_KEY_HEX, stamp, privateKey, ethAddress, charlieContact, {
       subject: testSubject,
       body: 'Full E2E flow test',
     })
 
     // 3. Alice sends on-chain notification to Charlie
-    const feedTopic = mailbox.feedTopic(overlay, charlieOverlay)
     const txHash = await registry.sendNotification(
       provider,
       CONTRACT_ADDRESS,
       secp.getPublicKey(charliePrivateKey, true),
       charlieEthAddress,
-      { sender: ethAddress, overlay, feedTopic },
+      { sender: ethAddress },
     )
     console.log(`  Full flow notification tx: ${txHash}`)
 
@@ -343,10 +322,9 @@ describe('full E2E flow: identity → message → notification → discovery', (
       nickname: 'Alice',
       walletPublicKey: discoveredAlice!.walletPublicKey,
       beePublicKey: discoveredAlice!.beePublicKey,
-      overlay: discoveredAlice!.overlay,
       addedAt: Date.now(),
     }
-    const messages = await mailbox.readMessages(bee, charliePrivateKey, charlieOverlay, aliceContact)
+    const messages = await mailbox.readMessages(bee, charliePrivateKey, charlieEthAddress, aliceContact)
 
     expect(messages).toHaveLength(1)
     expect(messages[0].subject).toBe(testSubject)

--- a/test/identity.test.ts
+++ b/test/identity.test.ts
@@ -32,7 +32,6 @@ describe('publish', () => {
       publish(bee, '0x' + 'aa'.repeat(32), 'stamp123', {
         walletPublicKey: '02' + 'ab'.repeat(32),
         beePublicKey: '04' + 'cd'.repeat(32),
-        overlay: 'ff'.repeat(32),
       }),
     ).rejects.toThrow('ethAddress is required')
   })
@@ -45,7 +44,6 @@ describe('publish', () => {
     const identity = {
       walletPublicKey: '02' + 'ab'.repeat(32),
       beePublicKey: '04' + 'cd'.repeat(32),
-      overlay: 'ff'.repeat(32),
       ethAddress: '0x1234567890abcdef1234567890abcdef12345678',
     }
 
@@ -62,7 +60,6 @@ describe('publish', () => {
     const parsed = JSON.parse(new TextDecoder().decode(payload))
     expect(parsed.walletPublicKey).toBe(identity.walletPublicKey)
     expect(parsed.beePublicKey).toBe(identity.beePublicKey)
-    expect(parsed.overlay).toBe(identity.overlay)
   })
 })
 
@@ -71,7 +68,6 @@ describe('resolve', () => {
     const identityData = {
       walletPublicKey: '02' + 'ab'.repeat(32),
       beePublicKey: '04' + 'cd'.repeat(32),
-      overlay: 'ff'.repeat(32),
     }
     const payload = new TextEncoder().encode(JSON.stringify(identityData))
     const downloadPayload = vi.fn().mockResolvedValue({
@@ -86,7 +82,6 @@ describe('resolve', () => {
     expect(result).not.toBeNull()
     expect(result!.walletPublicKey).toBe(identityData.walletPublicKey)
     expect(result!.beePublicKey).toBe(identityData.beePublicKey)
-    expect(result!.overlay).toBe(identityData.overlay)
     expect(result!.ethAddress).toBe(ethAddress.toLowerCase())
   })
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import * as secp from '@noble/secp256k1'
 import { bytesToHex } from '@noble/hashes/utils'
-import { keccak_256 } from '@noble/hashes/sha3'
 import { MockBee } from './helpers/mock-bee'
 import * as identity from '../src/identity'
 import * as mailbox from '../src/mailbox'
@@ -21,9 +20,8 @@ function makeUser() {
   const publicKey = secp.getPublicKey(privateKey, true)
   const publicKeyHex = bytesToHex(publicKey)
   const ethAddress = '0x' + bytesToHex(publicKey.slice(1, 21))
-  const overlay = bytesToHex(keccak_256(publicKey)).slice(0, 32)
   const beePublicKey = '04' + bytesToHex(secp.utils.randomPrivateKey())
-  return { privateKey, publicKey, publicKeyHex, ethAddress, overlay, beePublicKey }
+  return { privateKey, publicKey, publicKeyHex, ethAddress, beePublicKey }
 }
 
 function hexToBytes(hex: string): Uint8Array {
@@ -148,7 +146,6 @@ describe('identity: publish + resolve round-trip', () => {
     const swarmIdentity = {
       walletPublicKey: alice.publicKeyHex,
       beePublicKey: alice.beePublicKey,
-      overlay: alice.overlay,
       ethAddress: alice.ethAddress,
     }
 
@@ -161,7 +158,6 @@ describe('identity: publish + resolve round-trip', () => {
     expect(resolved).not.toBeNull()
     expect(resolved!.walletPublicKey).toBe(alice.publicKeyHex)
     expect(resolved!.beePublicKey).toBe(alice.beePublicKey)
-    expect(resolved!.overlay).toBe(alice.overlay)
   })
 
   it('returns null for non-existent identity', async () => {
@@ -177,7 +173,6 @@ describe('contacts: CRUD operations', () => {
     const swarmId = {
       walletPublicKey: alice.publicKeyHex,
       beePublicKey: alice.beePublicKey,
-      overlay: alice.overlay,
     }
 
     // Add
@@ -203,7 +198,6 @@ describe('contacts: CRUD operations', () => {
     const swarmId = {
       walletPublicKey: alice.publicKeyHex,
       beePublicKey: alice.beePublicKey,
-      overlay: alice.overlay,
     }
 
     contacts.add(alice.ethAddress, 'Alice', swarmId)
@@ -221,13 +215,11 @@ describe('full messaging flow: Alice ↔ Bob', () => {
     await identity.publish(bee as any, alice.ethAddress, STAMP, {
       walletPublicKey: alice.publicKeyHex,
       beePublicKey: alice.beePublicKey,
-      overlay: alice.overlay,
       ethAddress: alice.ethAddress,
     })
     await identity.publish(bee as any, bob.ethAddress, STAMP, {
       walletPublicKey: bob.publicKeyHex,
       beePublicKey: bob.beePublicKey,
-      overlay: bob.overlay,
       ethAddress: bob.ethAddress,
     })
 
@@ -243,7 +235,7 @@ describe('full messaging flow: Alice ↔ Bob', () => {
       alice.ethAddress, // signer
       STAMP,
       alice.privateKey,
-      alice.overlay,
+      alice.ethAddress,
       bobContact,
       { subject: 'Hello Bob', body: 'This is a test message from Alice' },
     )
@@ -252,14 +244,13 @@ describe('full messaging flow: Alice ↔ Bob', () => {
     const aliceContact = contacts.add(alice.ethAddress, 'Alice', {
       walletPublicKey: alice.publicKeyHex,
       beePublicKey: alice.beePublicKey,
-      overlay: alice.overlay,
     })
-    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.overlay, aliceContact)
+    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.ethAddress, aliceContact)
 
     expect(messages).toHaveLength(1)
     expect(messages[0].subject).toBe('Hello Bob')
     expect(messages[0].body).toBe('This is a test message from Alice')
-    expect(messages[0].sender).toBe(alice.overlay)
+    expect(messages[0].sender).toBe(alice.ethAddress)
     expect(messages[0].v).toBe(1)
     expect(messages[0].ts).toBeGreaterThan(0)
   })
@@ -274,7 +265,6 @@ describe('full messaging flow: Alice ↔ Bob', () => {
       nickname: 'Bob',
       walletPublicKey: bob.publicKeyHex,
       beePublicKey: bob.beePublicKey,
-      overlay: bob.overlay,
       addedAt: Date.now(),
     }
 
@@ -285,7 +275,7 @@ describe('full messaging flow: Alice ↔ Bob', () => {
         alice.ethAddress,
         STAMP,
         alice.privateKey,
-        alice.overlay,
+        alice.ethAddress,
         bobContact,
         { subject: `Message ${i}`, body: `Body ${i}` },
       )
@@ -297,10 +287,9 @@ describe('full messaging flow: Alice ↔ Bob', () => {
       nickname: 'Alice',
       walletPublicKey: alice.publicKeyHex,
       beePublicKey: alice.beePublicKey,
-      overlay: alice.overlay,
       addedAt: Date.now(),
     }
-    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.overlay, aliceContact)
+    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.ethAddress, aliceContact)
 
     expect(messages).toHaveLength(3)
     expect(messages[0].subject).toBe('Message 1')
@@ -318,7 +307,6 @@ describe('full messaging flow: Alice ↔ Bob', () => {
       nickname: 'Bob',
       walletPublicKey: bob.publicKeyHex,
       beePublicKey: bob.beePublicKey,
-      overlay: bob.overlay,
       addedAt: Date.now(),
     }
     const aliceContact = {
@@ -326,29 +314,28 @@ describe('full messaging flow: Alice ↔ Bob', () => {
       nickname: 'Alice',
       walletPublicKey: alice.publicKeyHex,
       beePublicKey: alice.beePublicKey,
-      overlay: alice.overlay,
       addedAt: Date.now(),
     }
 
     // Alice → Bob
-    await mailbox.send(bee as any, alice.ethAddress, STAMP, alice.privateKey, alice.overlay, bobContact, {
+    await mailbox.send(bee as any, alice.ethAddress, STAMP, alice.privateKey, alice.ethAddress, bobContact, {
       subject: 'Hi Bob',
       body: 'Hello from Alice',
     })
 
     // Bob → Alice
-    await mailbox.send(bee as any, bob.ethAddress, STAMP, bob.privateKey, bob.overlay, aliceContact, {
+    await mailbox.send(bee as any, bob.ethAddress, STAMP, bob.privateKey, bob.ethAddress, aliceContact, {
       subject: 'Hi Alice',
       body: 'Hello from Bob',
     })
 
     // Alice checks inbox — should see Bob's message
-    const aliceInbox = await mailbox.checkInbox(bee as any, alice.privateKey, alice.overlay, [bobContact])
+    const aliceInbox = await mailbox.checkInbox(bee as any, alice.privateKey, alice.ethAddress, [bobContact])
     expect(aliceInbox).toHaveLength(1)
     expect(aliceInbox[0].messages[0].subject).toBe('Hi Alice')
 
     // Bob checks inbox — should see Alice's message
-    const bobInbox = await mailbox.checkInbox(bee as any, bob.privateKey, bob.overlay, [aliceContact])
+    const bobInbox = await mailbox.checkInbox(bee as any, bob.privateKey, bob.ethAddress, [aliceContact])
     expect(bobInbox).toHaveLength(1)
     expect(bobInbox[0].messages[0].subject).toBe('Hi Bob')
   })
@@ -363,8 +350,6 @@ describe('registry notification flow', () => {
     // Bob sends notification to Alice (first contact)
     const payload: NotificationPayload = {
       sender: bob.ethAddress,
-      overlay: bob.overlay,
-      feedTopic: mailbox.feedTopic(bob.overlay, alice.overlay),
     }
 
     await registry.sendNotification(
@@ -385,8 +370,6 @@ describe('registry notification flow', () => {
 
     expect(notifications).toHaveLength(1)
     expect(notifications[0].payload.sender).toBe(bob.ethAddress)
-    expect(notifications[0].payload.overlay).toBe(bob.overlay)
-    expect(notifications[0].payload.feedTopic).toBe(payload.feedTopic)
     expect(notifications[0].blockNumber).toBe(1)
   })
 
@@ -398,8 +381,6 @@ describe('registry notification flow', () => {
     // Bob sends a valid notification
     const validPayload: NotificationPayload = {
       sender: bob.ethAddress,
-      overlay: bob.overlay,
-      feedTopic: 'valid-topic',
     }
     await registry.sendNotification(provider, CONTRACT, alice.publicKey, alice.ethAddress, validPayload)
 
@@ -407,8 +388,6 @@ describe('registry notification flow', () => {
     const spammer = makeUser()
     const spamPayload: NotificationPayload = {
       sender: spammer.ethAddress,
-      overlay: spammer.overlay,
-      feedTopic: 'spam-topic',
     }
     // Encrypt with spammer's own key instead of Alice's — Alice can't decrypt this
     const spamBytes = new TextEncoder().encode(JSON.stringify(spamPayload))
@@ -435,21 +414,21 @@ describe('registry notification flow', () => {
     const provider = createMockProvider()
 
     // Three different senders notify Alice
+    const senders: ReturnType<typeof makeUser>[] = []
     for (let i = 0; i < 3; i++) {
       const sender = makeUser()
+      senders.push(sender)
       const payload: NotificationPayload = {
         sender: sender.ethAddress,
-        overlay: sender.overlay,
-        feedTopic: `topic-${i}`,
       }
       await registry.sendNotification(provider, CONTRACT, alice.publicKey, alice.ethAddress, payload)
     }
 
     const notifications = await registry.pollNotifications(provider, CONTRACT, alice.ethAddress, alice.privateKey)
     expect(notifications).toHaveLength(3)
-    expect(notifications[0].payload.feedTopic).toBe('topic-0')
-    expect(notifications[1].payload.feedTopic).toBe('topic-1')
-    expect(notifications[2].payload.feedTopic).toBe('topic-2')
+    expect(notifications[0].payload.sender).toBe(senders[0].ethAddress)
+    expect(notifications[1].payload.sender).toBe(senders[1].ethAddress)
+    expect(notifications[2].payload.sender).toBe(senders[2].ethAddress)
   })
 
   it('fromBlock filters old notifications', async () => {
@@ -457,21 +436,23 @@ describe('registry notification flow', () => {
     const provider = createMockProvider()
 
     // Send two notifications (block 1 and block 2)
+    const senders: ReturnType<typeof makeUser>[] = []
     for (let i = 0; i < 2; i++) {
       const sender = makeUser()
+      senders.push(sender)
       await registry.sendNotification(
         provider,
         CONTRACT,
         alice.publicKey,
         alice.ethAddress,
-        { sender: sender.ethAddress, overlay: sender.overlay, feedTopic: `topic-${i}` },
+        { sender: sender.ethAddress },
       )
     }
 
     // Poll from block 2 — should only get the second one
     const notifications = await registry.pollNotifications(provider, CONTRACT, alice.ethAddress, alice.privateKey, 2)
     expect(notifications).toHaveLength(1)
-    expect(notifications[0].payload.feedTopic).toBe('topic-1')
+    expect(notifications[0].payload.sender).toBe(senders[1].ethAddress)
   })
 })
 
@@ -486,13 +467,11 @@ describe('end-to-end: discovery → messaging', () => {
     await identity.publish(bee as any, alice.ethAddress, STAMP, {
       walletPublicKey: alice.publicKeyHex,
       beePublicKey: alice.beePublicKey,
-      overlay: alice.overlay,
       ethAddress: alice.ethAddress,
     })
     await identity.publish(bee as any, bob.ethAddress, STAMP, {
       walletPublicKey: bob.publicKeyHex,
       beePublicKey: bob.beePublicKey,
-      overlay: bob.overlay,
       ethAddress: bob.ethAddress,
     })
 
@@ -503,23 +482,21 @@ describe('end-to-end: discovery → messaging', () => {
       nickname: 'Bob',
       walletPublicKey: bobId!.walletPublicKey,
       beePublicKey: bobId!.beePublicKey,
-      overlay: bobId!.overlay,
       addedAt: Date.now(),
     }
 
-    await mailbox.send(bee as any, alice.ethAddress, STAMP, alice.privateKey, alice.overlay, bobContact, {
+    await mailbox.send(bee as any, alice.ethAddress, STAMP, alice.privateKey, alice.ethAddress, bobContact, {
       subject: 'Project files',
       body: 'Attached the latest version',
     })
 
     // 3. Alice sends on-chain notification to Bob (first contact)
-    const feedTopic = mailbox.feedTopic(alice.overlay, bob.overlay)
     await registry.sendNotification(
       provider,
       CONTRACT,
       bob.publicKey,
       bob.ethAddress,
-      { sender: alice.ethAddress, overlay: alice.overlay, feedTopic },
+      { sender: alice.ethAddress },
     )
 
     // 4. Bob polls registry — discovers Alice
@@ -539,10 +516,9 @@ describe('end-to-end: discovery → messaging', () => {
       nickname: 'Alice',
       walletPublicKey: aliceId!.walletPublicKey,
       beePublicKey: aliceId!.beePublicKey,
-      overlay: aliceId!.overlay,
       addedAt: Date.now(),
     }
-    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.overlay, aliceContact)
+    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.ethAddress, aliceContact)
 
     expect(messages).toHaveLength(1)
     expect(messages[0].subject).toBe('Project files')

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -525,3 +525,98 @@ describe('end-to-end: discovery → messaging', () => {
     expect(messages[0].body).toBe('Attached the latest version')
   })
 })
+
+// ─── Multi-device stability tests (regression guards) ───────────
+
+describe('multi-device stability: ETH address based feed topics', () => {
+  it('same ethAddress pair always produces the same feed topic', () => {
+    const alice = makeUser()
+    const bob = makeUser()
+
+    // Simulates the same wallet on two different devices — same ETH address
+    const topic1 = mailbox.feedTopic(alice.ethAddress, bob.ethAddress)
+    const topic2 = mailbox.feedTopic(alice.ethAddress, bob.ethAddress)
+
+    expect(topic1).toBe(topic2)
+  })
+
+  it('feed topic is independent of any per-device value', () => {
+    // Two "devices" for Alice — different private keys but same ETH address
+    const aliceEth = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const bobEth = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+    // The topic depends ONLY on ethAddress, not on any device-specific value
+    const topic = mailbox.feedTopic(aliceEth, bobEth)
+    expect(topic).toMatch(/^[0-9a-f]{64}$/)
+
+    // Calling again with the exact same addresses = same topic (trivial but guards regressions)
+    expect(mailbox.feedTopic(aliceEth, bobEth)).toBe(topic)
+  })
+
+  it('recipient can derive feedTopic from just the sender ethAddress', () => {
+    const alice = makeUser()
+    const bob = makeUser()
+
+    // Alice sends notification with just { sender: alice.ethAddress }
+    const payload: NotificationPayload = { sender: alice.ethAddress }
+
+    // Bob receives the notification and derives the feed topic
+    const derivedTopic = mailbox.feedTopic(payload.sender, bob.ethAddress)
+
+    // This should match the topic Alice used to write her messages
+    const aliceTopic = mailbox.feedTopic(alice.ethAddress, bob.ethAddress)
+    expect(derivedTopic).toBe(aliceTopic)
+  })
+
+  it('identity publish/resolve roundtrip without overlay', async () => {
+    const bee = new MockBee()
+    const alice = makeUser()
+
+    const published = {
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      ethAddress: alice.ethAddress,
+    }
+
+    await identity.publish(bee as any, alice.ethAddress, 'stamp', published)
+    const resolved = await identity.resolve(bee as any, alice.ethAddress)
+
+    expect(resolved).not.toBeNull()
+    expect(resolved!.walletPublicKey).toBe(published.walletPublicKey)
+    expect(resolved!.beePublicKey).toBe(published.beePublicKey)
+    expect(resolved).not.toHaveProperty('overlay')
+  })
+
+  it('Message.sender contains ethAddress, not overlay', async () => {
+    const bee = new MockBee()
+    const alice = makeUser()
+    const bob = makeUser()
+
+    const bobContact = {
+      ethAddress: bob.ethAddress.toLowerCase(),
+      nickname: 'Bob',
+      walletPublicKey: bob.publicKeyHex,
+      beePublicKey: bob.beePublicKey,
+      addedAt: Date.now(),
+    }
+
+    await mailbox.send(bee as any, alice.ethAddress, 'stamp', alice.privateKey, alice.ethAddress, bobContact, {
+      subject: 'Test',
+      body: 'Sender check',
+    })
+
+    const aliceContact = {
+      ethAddress: alice.ethAddress.toLowerCase(),
+      nickname: 'Alice',
+      walletPublicKey: alice.publicKeyHex,
+      beePublicKey: alice.beePublicKey,
+      addedAt: Date.now(),
+    }
+    const messages = await mailbox.readMessages(bee as any, bob.privateKey, bob.ethAddress, aliceContact)
+
+    expect(messages).toHaveLength(1)
+    // sender should be an ETH address, not an overlay
+    expect(messages[0].sender).toBe(alice.ethAddress)
+    expect(messages[0].sender).toMatch(/^0x[0-9a-f]{40}$/)
+  })
+})

--- a/test/mailbox.test.ts
+++ b/test/mailbox.test.ts
@@ -16,13 +16,12 @@ function makeKeypair() {
   }
 }
 
-function makeContact(overlay: string, keypair: ReturnType<typeof makeKeypair>): Contact {
+function makeContact(keypair: ReturnType<typeof makeKeypair>): Contact {
   return {
     ethAddress: keypair.address,
     nickname: 'Test',
     walletPublicKey: keypair.publicKeyHex,
     beePublicKey: '04' + 'cc'.repeat(32),
-    overlay,
     addedAt: Date.now(),
   }
 }
@@ -53,9 +52,7 @@ describe('send + readMessages', () => {
   it('round-trip: send a message, read it back', async () => {
     const alice = makeKeypair()
     const bob = makeKeypair()
-    const aliceOverlay = 'aa'.repeat(16)
-    const bobOverlay = 'bb'.repeat(16)
-    const bobContact = makeContact(bobOverlay, bob)
+    const bobContact = makeContact(bob)
 
     // Track what gets uploaded and written to feed
     let uploadedBlob: Uint8Array | null = null
@@ -85,7 +82,7 @@ describe('send + readMessages', () => {
       '0x' + bytesToHex(alice.privateKey),
       'stamp123',
       alice.privateKey,
-      aliceOverlay,
+      alice.address,
       bobContact,
       { subject: 'Hello', body: 'First message' },
     )
@@ -104,23 +101,21 @@ describe('send + readMessages', () => {
     })
     const beeRead = { makeFeedReader: makeFeedReaderForRead } as any
 
-    const aliceContact = makeContact(aliceOverlay, alice)
-    const messages = await readMessages(beeRead, bob.privateKey, bobOverlay, aliceContact)
+    const aliceContact = makeContact(alice)
+    const messages = await readMessages(beeRead, bob.privateKey, bob.address, aliceContact)
 
     expect(messages).toHaveLength(1)
     expect(messages[0].subject).toBe('Hello')
     expect(messages[0].body).toBe('First message')
     expect(messages[0].v).toBe(1)
-    expect(messages[0].sender).toBe(aliceOverlay)
+    expect(messages[0].sender).toBe(alice.address)
     expect(messages[0].ts).toBeGreaterThan(0)
   })
 
   it('send multiple messages: array grows', async () => {
     const alice = makeKeypair()
     const bob = makeKeypair()
-    const aliceOverlay = 'aa'.repeat(16)
-    const bobOverlay = 'bb'.repeat(16)
-    const bobContact = makeContact(bobOverlay, bob)
+    const bobContact = makeContact(bob)
 
     let uploadedBlob: Uint8Array | null = null
     const uploadData = vi.fn().mockImplementation((_stamp: string, data: Uint8Array) => {
@@ -140,7 +135,7 @@ describe('send + readMessages', () => {
     })
     const bee = { uploadData, makeFeedWriter, makeFeedReader } as any
 
-    await send(bee, '0x' + bytesToHex(alice.privateKey), 'stamp', alice.privateKey, aliceOverlay, bobContact, {
+    await send(bee, '0x' + bytesToHex(alice.privateKey), 'stamp', alice.privateKey, alice.address, bobContact, {
       subject: 'Msg 1',
       body: 'First',
     })
@@ -155,7 +150,7 @@ describe('send + readMessages', () => {
     })
     const bee2 = { uploadData, makeFeedWriter, makeFeedReader: makeFeedReader2 } as any
 
-    await send(bee2, '0x' + bytesToHex(alice.privateKey), 'stamp', alice.privateKey, aliceOverlay, bobContact, {
+    await send(bee2, '0x' + bytesToHex(alice.privateKey), 'stamp', alice.privateKey, alice.address, bobContact, {
       subject: 'Msg 2',
       body: 'Second',
     })
@@ -167,8 +162,8 @@ describe('send + readMessages', () => {
       }),
     })
     const beeRead = { makeFeedReader: makeFeedReaderRead } as any
-    const aliceContact = makeContact(aliceOverlay, alice)
-    const messages = await readMessages(beeRead, bob.privateKey, bobOverlay, aliceContact)
+    const aliceContact = makeContact(alice)
+    const messages = await readMessages(beeRead, bob.privateKey, bob.address, aliceContact)
 
     expect(messages).toHaveLength(2)
     expect(messages[0].subject).toBe('Msg 1')
@@ -184,9 +179,9 @@ describe('readMessages edge cases', () => {
       downloadPayload: vi.fn().mockRejectedValue(new Error('Not found')),
     })
     const bee = { makeFeedReader } as any
-    const aliceContact = makeContact('aa'.repeat(16), alice)
+    const aliceContact = makeContact(alice)
 
-    const messages = await readMessages(bee, bob.privateKey, 'bb'.repeat(16), aliceContact)
+    const messages = await readMessages(bee, bob.privateKey, bob.address, aliceContact)
     expect(messages).toEqual([])
   })
 })
@@ -196,9 +191,6 @@ describe('checkInbox', () => {
     const me = makeKeypair()
     const alice = makeKeypair()
     const bob = makeKeypair()
-    const myOverlay = 'cc'.repeat(16)
-    const aliceOverlay = 'aa'.repeat(16)
-    const bobOverlay = 'bb'.repeat(16)
 
     // Simulate: alice sent me a message, bob's feed is empty
     // We need to create encrypted blobs for alice's messages
@@ -206,7 +198,7 @@ describe('checkInbox', () => {
     const alicePubBytes = hexToBytes(alice.publicKeyHex)
     const sharedWithAlice = deriveSharedSecret(me.privateKey, alicePubBytes)
 
-    const aliceMessages = [{ v: 1, subject: 'Hi', body: 'From Alice', ts: 1000, sender: aliceOverlay }]
+    const aliceMessages = [{ v: 1, subject: 'Hi', body: 'From Alice', ts: 1000, sender: alice.address }]
     const plaintext = new TextEncoder().encode(JSON.stringify(aliceMessages))
     const encrypted = await encrypt(plaintext, sharedWithAlice)
     const blob = new Uint8Array(12 + encrypted.ciphertext.length)
@@ -231,10 +223,10 @@ describe('checkInbox', () => {
     })
     const bee = { makeFeedReader } as any
 
-    const aliceContact = makeContact(aliceOverlay, alice)
-    const bobContact = makeContact(bobOverlay, bob)
+    const aliceContact = makeContact(alice)
+    const bobContact = makeContact(bob)
 
-    const inbox = await checkInbox(bee, me.privateKey, myOverlay, [aliceContact, bobContact])
+    const inbox = await checkInbox(bee, me.privateKey, me.address, [aliceContact, bobContact])
 
     // Only Alice should appear (Bob has no messages)
     expect(inbox).toHaveLength(1)

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -91,8 +91,6 @@ const CONTRACT_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678'
 
 const SAMPLE_PAYLOAD: NotificationPayload = {
   sender: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-  overlay: 'abc123overlay',
-  feedTopic: 'feedtopic456',
 }
 
 // ─── Tests ──────────────────────────────────────────────────────
@@ -321,18 +319,12 @@ describe('pollNotifications', () => {
 
     const payload1: NotificationPayload = {
       sender: '0x1111111111111111111111111111111111111111',
-      overlay: 'overlay1',
-      feedTopic: 'topic1',
     }
     const payload2: NotificationPayload = {
       sender: '0x2222222222222222222222222222222222222222',
-      overlay: 'overlay2',
-      feedTopic: 'topic2',
     }
     const payload3: NotificationPayload = {
       sender: '0x3333333333333333333333333333333333333333',
-      overlay: 'overlay3',
-      feedTopic: 'topic3',
     }
 
     const enc1 = await eciesEncrypt(new TextEncoder().encode(JSON.stringify(payload1)), recipientPubKey)
@@ -363,8 +355,6 @@ describe('pollNotifications', () => {
 
     const validPayload: NotificationPayload = {
       sender: '0x1111111111111111111111111111111111111111',
-      overlay: 'overlay1',
-      feedTopic: 'topic1',
     }
 
     // Valid notification

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: ['test/e2e.test.ts', 'node_modules/**'],
+    exclude: ['test/e2e.test.ts', 'node_modules/**', 'examples/**/node_modules/**', 'examples/**/tests/**'],
   },
 })


### PR DESCRIPTION
## Summary

Removes `overlay` (Bee node DHT address) from the entire API surface. ETH address is now the sole identifier for feed topics, contacts, and notification payloads.

### What changed

| Area | Before | After |
|------|--------|-------|
| `SwarmIdentity` | `{ walletPublicKey, beePublicKey, overlay }` | `{ walletPublicKey, beePublicKey }` |
| `Contact` | includes `overlay` | overlay removed |
| `mailbox.feedTopic` | `keccak(senderOverlay + recipientOverlay + suffix)` | `keccak(senderEthAddr + recipientEthAddr + suffix)` |
| `mailbox.send/read/inbox` | `myOverlay` param | `myEthAddress` param |
| `Message.sender` | overlay | ethAddress |
| `NotificationPayload` | `{ sender, overlay, feedTopic }` | `{ sender }` |

### Benefits
- Mailbox feeds survive device migration (same wallet = same feed topics)
- Multi-device messaging (laptop + phone = same inbox)
- Notification payload shrinks to 1 field (cheaper gas)
- One less per-device concept for host apps to manage

### Commits (7)
1. Remove overlay from types
2. Remove from identity publish/resolve
3. Replace in mailbox module (feedTopic, send, read, inbox)
4. Remove from ContactStore
5. Update all call sites (CLI, web UI, tests)
6. Add 5 multi-device stability regression tests
7. Update all docs (CLAUDE.md, integration guide, web UI)

## Test plan
- [x] `npm test` — 71 tests pass (66 existing + 5 new)
- [x] `npm run check:types` — clean
- [x] Net -69 lines (simplified API)

Closes #36, #37, #38, #39.