### PR TITLE
Fix: restore missing keccak_256 import in E2E tests (#43)

### DIFF
--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -13,6 +13,7 @@ import 'dotenv/config'
 import { describe, it, expect, beforeAll } from 'vitest'
 import { Bee } from '@ethersphere/bee-js'
 import * as secp from '@noble/secp256k1'
+import { keccak_256 } from '@noble/hashes/sha3'
 import { bytesToHex } from '@noble/hashes/utils'
 
 import * as identity from '../src/identity'


### PR DESCRIPTION
One-line fix: add back `import { keccak_256 } from '@noble/hashes/sha3'` to `test/e2e.test.ts`.

The import was removed during overlay cleanup (#36) but `getEthAddress()` still needs it.

Closes #43.