### PR TITLE
Developer docs, agent guide, and reference app polish (#47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,7 @@ registry.ts (depends on: crypto, NotifyProvider interface — no ethers, no Swar
 - When code or logic changes in any module (`src/`), check whether **all** of the following need updating:
   - Reference CLI app (`examples/cli.ts`)
   - Web UI reference app (`examples/web/`) — including step descriptions, use case cards, privacy table, and flow diagrams
+  - Agent integration guide (`docs/agent-integration.md`) and polling agent example (`examples/agent/`)
   - Unit tests, integration tests (`test/integration.test.ts`), and E2E tests (`test/e2e.test.ts`)
   - Playwright tests (`examples/web/tests/`)
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,0 +1,330 @@
+# Agent Integration Guide
+
+How to use Swarm Notify in autonomous agents, bots, and backend services.
+
+Agents use the same library API as interactive apps. The key differences: agents manage keys programmatically, poll automatically, and run headless (Node.js, no browser). The [CLI reference app](../examples/cli.ts) is a good starting point — the [polling agent example](../examples/agent/) is a more complete template.
+
+## Key Management
+
+Agents don't have wallet UIs. Generate and persist keys on first run.
+
+```typescript
+import * as fs from 'fs'
+import * as secp from '@noble/secp256k1'
+import { bytesToHex } from '@noble/hashes/utils'
+import { keccak_256 } from '@noble/hashes/sha3'
+
+const KEY_FILE = './data/agent-key.json'
+
+function loadOrCreateKey(): { privateKey: Uint8Array; ethAddress: string } {
+  if (fs.existsSync(KEY_FILE)) {
+    const { hex } = JSON.parse(fs.readFileSync(KEY_FILE, 'utf-8'))
+    const privateKey = hexToBytes(hex)
+    return { privateKey, ethAddress: deriveEthAddress(privateKey) }
+  }
+
+  const privateKey = secp.utils.randomPrivateKey()
+  const hex = bytesToHex(privateKey)
+  fs.mkdirSync('./data', { recursive: true })
+  fs.writeFileSync(KEY_FILE, JSON.stringify({ hex }))
+  return { privateKey, ethAddress: deriveEthAddress(privateKey) }
+}
+
+function deriveEthAddress(privateKey: Uint8Array): string {
+  const pubKey = secp.getPublicKey(privateKey, false)
+  const hash = keccak_256(pubKey.slice(1))
+  return '0x' + bytesToHex(hash.slice(12))
+}
+```
+
+**Key rotation:** Republish identity (`identity.publish()`) after generating a new key. Contacts who cached your old public key will need to re-resolve your identity feed.
+
+## Identity Lifecycle
+
+Publish your identity on agent startup so other agents can discover you:
+
+```typescript
+import { Bee } from '@ethersphere/bee-js'
+import * as identity from '@swarm-notify/sdk/identity'
+
+const bee = new Bee('http://localhost:1633')
+const { privateKey, ethAddress } = loadOrCreateKey()
+const publicKeyHex = bytesToHex(secp.getPublicKey(privateKey, true))
+
+// Publish once on startup (idempotent — overwrites previous)
+await identity.publish(bee, '0x' + bytesToHex(privateKey), stamp, {
+  walletPublicKey: publicKeyHex,
+  beePublicKey: publicKeyHex,
+  ethAddress,
+})
+
+console.log(`Agent identity published: ${ethAddress}`)
+```
+
+Share your ETH address with other agents however your system works — config file, on-chain registry, environment variable, etc.
+
+## Contact Management
+
+Use `ContactStore` with file-based persistence:
+
+```typescript
+import { ContactStore } from '@swarm-notify/sdk'
+
+const CONTACTS_FILE = './data/contacts.json'
+
+function loadContacts(): ContactStore {
+  try {
+    return ContactStore.from(JSON.parse(fs.readFileSync(CONTACTS_FILE, 'utf-8')))
+  } catch { return new ContactStore() }
+}
+
+function saveContacts(store: ContactStore): void {
+  fs.writeFileSync(CONTACTS_FILE, JSON.stringify(store.export()))
+}
+```
+
+## Automated Polling
+
+The core pattern for agents: a loop that checks for new messages and notifications.
+
+### Inbox polling
+
+```typescript
+import * as mailbox from '@swarm-notify/sdk/mailbox'
+
+async function pollInbox(contacts: ContactStore): Promise<void> {
+  const inbox = await mailbox.checkInbox(
+    bee, privateKey, ethAddress, contacts.list()
+  )
+
+  for (const { contact, messages } of inbox) {
+    for (const msg of messages) {
+      console.log(`[${contact.nickname}] ${msg.subject}: ${msg.body}`)
+      await handleMessage(contact, msg)
+    }
+  }
+}
+```
+
+### Registry polling (discover new contacts)
+
+Track the last processed block to avoid reprocessing:
+
+```typescript
+import * as registry from '@swarm-notify/sdk/registry'
+
+const BLOCK_FILE = './data/last-block.txt'
+
+function loadLastBlock(): number {
+  try { return parseInt(fs.readFileSync(BLOCK_FILE, 'utf-8')) } catch { return 0 }
+}
+
+function saveLastBlock(block: number): void {
+  fs.writeFileSync(BLOCK_FILE, String(block))
+}
+
+async function pollNotifications(contacts: ContactStore): Promise<void> {
+  const fromBlock = loadLastBlock()
+  const notifications = await registry.pollNotifications(
+    notifyProvider, contractAddress, ethAddress, privateKey, fromBlock
+  )
+
+  for (const { payload, blockNumber } of notifications) {
+    console.log(`New contact discovered: ${payload.sender} (block ${blockNumber})`)
+
+    // Resolve and add as contact
+    const id = await identity.resolve(bee, payload.sender)
+    if (id) {
+      try {
+        contacts.add(payload.sender, payload.sender, id)
+        saveContacts(contacts)
+      } catch { /* already exists */ }
+    }
+
+    saveLastBlock(blockNumber + 1)
+  }
+}
+```
+
+### Main polling loop
+
+```typescript
+const POLL_INTERVAL = 30_000 // 30 seconds
+
+async function runAgent(): Promise<void> {
+  const { privateKey, ethAddress } = loadOrCreateKey()
+  const contacts = loadContacts()
+
+  // Publish identity on startup
+  await publishIdentity()
+
+  console.log(`Agent running. Polling every ${POLL_INTERVAL / 1000}s...`)
+
+  while (true) {
+    try {
+      await pollNotifications(contacts)
+      await pollInbox(contacts)
+    } catch (err) {
+      console.error('Poll error:', err instanceof Error ? err.message : err)
+      // Don't crash — wait and retry
+    }
+
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL))
+  }
+}
+
+runAgent()
+```
+
+## Error Recovery
+
+### Bee node restarts
+
+The Bee node may restart or become temporarily unreachable. Wrap Swarm operations in retry logic:
+
+```typescript
+async function withRetry<T>(fn: () => Promise<T>, retries = 3, delay = 5000): Promise<T> {
+  for (let i = 0; i < retries; i++) {
+    try { return await fn() }
+    catch (err) {
+      if (i === retries - 1) throw err
+      console.warn(`Retry ${i + 1}/${retries} in ${delay}ms...`)
+      await new Promise(r => setTimeout(r, delay))
+    }
+  }
+  throw new Error('unreachable')
+}
+
+// Usage
+await withRetry(() => mailbox.send(bee, signer, stamp, privateKey, ethAddress, contact, message))
+```
+
+### Transaction failures
+
+On-chain notifications may fail due to:
+- **Insufficient funds** — agent wallet needs xDAI on Gnosis Chain
+- **Nonce conflicts** — if agent sends multiple tx rapidly
+- **RPC timeouts** — public RPCs can be slow
+
+For production agents, consider using a dedicated RPC endpoint and monitoring the agent wallet balance.
+
+### Stamp expiry
+
+Postage stamps expire. Production agents should monitor stamp availability:
+
+```typescript
+const stamps = await bee.getAllPostageBatch()
+const usable = stamps.find(s => s.usable)
+if (!usable) {
+  console.error('No usable stamp — buy a new batch')
+  // Alert, pause operations, or auto-purchase
+}
+```
+
+## Communication Patterns
+
+### Request/Response
+
+Agent A sends a task, Agent B replies with results:
+
+```typescript
+// Agent A: send task
+await mailbox.send(bee, signer, stamp, privateKey, ethAddress, agentBContact, {
+  subject: 'task:analyze',
+  body: JSON.stringify({ dataset: 'swarm://ref/abc123', params: { threshold: 0.8 } }),
+})
+
+// Agent B: process and reply
+const messages = await mailbox.readMessages(bee, privateKey, ethAddress, agentAContact)
+for (const msg of messages) {
+  if (msg.subject.startsWith('task:')) {
+    const result = await processTask(JSON.parse(msg.body))
+    await mailbox.send(bee, signer, stamp, privateKey, ethAddress, agentAContact, {
+      subject: `result:${msg.subject}`,
+      body: JSON.stringify(result),
+    })
+  }
+}
+```
+
+**Convention:** Use structured `subject` prefixes (`task:`, `result:`, `status:`) for message routing.
+
+### Pub/Sub via Registry
+
+A service agent broadcasts to subscribers:
+
+```typescript
+// Publisher: notify all known subscribers
+for (const subscriber of contacts.list()) {
+  await registry.sendNotification(
+    notifyProvider, contractAddress,
+    hexToBytes(subscriber.walletPublicKey),
+    subscriber.ethAddress,
+    { sender: myEthAddress },
+  )
+}
+
+// Subscriber: poll for new publishers, then read their feeds
+const notifications = await registry.pollNotifications(...)
+// Add new publishers as contacts, then checkInbox to get updates
+```
+
+**Cost:** First notification per subscriber costs gas (~22k). Subsequent updates go through Swarm feeds only — free.
+
+### Drive Sharing
+
+Share datasets or files between agents:
+
+```typescript
+await mailbox.send(bee, signer, stamp, privateKey, ethAddress, recipientContact, {
+  subject: 'Shared: Training data Q4',
+  body: 'Updated dataset for the analysis pipeline.',
+  type: 'drive-share',
+  driveShareLink: 'swarm://feed?topic=abc&owner=def',
+  driveName: 'Training data Q4',
+  fileCount: 142,
+})
+```
+
+### Multi-Agent Coordination
+
+Fan-out (one sender, many recipients):
+
+```typescript
+const status = { subject: 'status:pipeline', body: JSON.stringify({ stage: 'complete', output: ref }) }
+for (const agent of contacts.list()) {
+  await mailbox.send(bee, signer, stamp, privateKey, ethAddress, agent, status)
+}
+```
+
+Fan-in (many senders, one aggregator):
+
+```typescript
+// Aggregator polls all known agents
+const inbox = await mailbox.checkInbox(bee, privateKey, ethAddress, contacts.list())
+const results = inbox.flatMap(({ messages }) =>
+  messages.filter(m => m.subject.startsWith('result:')).map(m => JSON.parse(m.body))
+)
+```
+
+## Running Headless
+
+Agents run in Node.js without a browser. Key setup:
+
+```typescript
+import 'dotenv/config'
+import { Bee } from '@ethersphere/bee-js'
+
+const bee = new Bee(process.env.BEE_URL || 'http://localhost:1633')
+const stamp = process.env.STAMP || ''
+const contractAddress = process.env.CONTRACT_ADDRESS || '0x318aE190B77bA39fbcdFA4e84BB7CFD16b846Fcf'
+```
+
+For the `NotifyProvider`, see the [CLI provider](../examples/provider.ts) — it uses raw `fetch` for reads and ethers for signing.
+
+## See Also
+
+- [Polling agent example](../examples/agent/) — complete runnable template
+- [CLI reference app](../examples/cli.ts) — interactive command-line usage
+- [Integration guide](./integration-guide.md) — general library integration
+- [Web UI demo](../examples/web/) — visual demo with explanations

--- a/examples/agent/README.md
+++ b/examples/agent/README.md
@@ -1,0 +1,53 @@
+# Polling Agent — Minimal Template
+
+A runnable autonomous agent that publishes its identity, polls for new contacts and messages, and auto-responds.
+
+## Setup
+
+```bash
+# From the project root
+export BEE_URL=http://localhost:1633
+export STAMP=<your-postage-batch-id>
+
+# Optional
+export GNOSIS_RPC_URL=https://rpc.gnosischain.com
+export CONTRACT_ADDRESS=0x318aE190B77bA39fbcdFA4e84BB7CFD16b846Fcf
+export POLL_INTERVAL=30000  # ms, default 30s
+```
+
+## Run
+
+```bash
+npx ts-node examples/agent/index.ts
+```
+
+## What it does
+
+1. **Startup:** Generates or loads a key pair from `data/agent/key.json`
+2. **Publishes identity** to Swarm (so other agents can discover it)
+3. **Polling loop** (every 30s):
+   - Polls Gnosis Chain for new notification events (discovers new contacts)
+   - Checks inbox across all known contacts
+   - Auto-responds with an acknowledgment to any new message
+4. **Persists** contacts (`data/agent/contacts.json`) and last-processed block (`data/agent/last-block.txt`)
+
+## Data
+
+All state is stored in `data/agent/`:
+
+| File | Purpose |
+|------|---------|
+| `key.json` | Agent's private key (hex) |
+| `contacts.json` | Known contacts (ContactStore export) |
+| `last-block.txt` | Last processed block number for registry polling |
+
+## Customization
+
+- **Message handling:** Edit `handleMessage()` to process incoming messages (currently echo/ack)
+- **Poll interval:** Set `POLL_INTERVAL` env var (ms)
+- **Sending notifications:** The agent uses a read-only provider. To send on-chain notifications, replace `createProvider()` with a signing provider (see `examples/provider.ts`)
+
+## See Also
+
+- [Agent integration guide](../../docs/agent-integration.md) — full guide with patterns
+- [CLI reference app](../cli.ts) — interactive command-line usage

--- a/examples/agent/index.ts
+++ b/examples/agent/index.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Minimal polling agent — a runnable template for autonomous agents.
+ *
+ * On startup: loads or generates a key, publishes identity.
+ * Loop: polls for new notifications (new contacts), checks inbox, auto-responds.
+ *
+ * Usage:
+ *   export BEE_URL=http://localhost:1633 STAMP=<batch-id>
+ *   npx ts-node examples/agent/index.ts
+ *
+ * See docs/agent-integration.md for the full guide.
+ */
+
+import 'dotenv/config'
+import * as fs from 'fs'
+import * as path from 'path'
+import { Bee } from '@ethersphere/bee-js'
+import * as secp from '@noble/secp256k1'
+import { bytesToHex } from '@noble/hashes/utils'
+import { keccak_256 } from '@noble/hashes/sha3'
+
+import * as identity from '../../src/identity'
+import * as mailbox from '../../src/mailbox'
+import * as registry from '../../src/registry'
+import { ContactStore } from '../../src/contacts'
+import type { Contact, Message, NotifyProvider } from '../../src/types'
+
+// ─── Config ─────────────────────────────────────────────────────
+
+const BEE_URL = process.env.BEE_URL || 'http://localhost:1633'
+const STAMP = process.env.STAMP || ''
+const GNOSIS_RPC = process.env.GNOSIS_RPC_URL || 'https://rpc.gnosischain.com'
+const CONTRACT = process.env.CONTRACT_ADDRESS || '0x318aE190B77bA39fbcdFA4e84BB7CFD16b846Fcf'
+const POLL_INTERVAL = parseInt(process.env.POLL_INTERVAL || '30000')
+const DATA_DIR = path.resolve('./data/agent')
+
+// ─── Persistence helpers ────────────────────────────────────────
+
+function ensureDataDir(): void {
+  fs.mkdirSync(DATA_DIR, { recursive: true })
+}
+
+function keyPath(): string { return path.join(DATA_DIR, 'key.json') }
+function contactsPath(): string { return path.join(DATA_DIR, 'contacts.json') }
+function blockPath(): string { return path.join(DATA_DIR, 'last-block.txt') }
+
+// ─── Key management ─────────────────────────────────────────────
+
+function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(h.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(h.substring(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+function deriveEthAddress(privateKey: Uint8Array): string {
+  const pubKey = secp.getPublicKey(privateKey, false)
+  const hash = keccak_256(pubKey.slice(1))
+  return '0x' + bytesToHex(hash.slice(12))
+}
+
+function loadOrCreateKey(): { privateKey: Uint8Array; ethAddress: string; publicKeyHex: string } {
+  if (fs.existsSync(keyPath())) {
+    const { hex } = JSON.parse(fs.readFileSync(keyPath(), 'utf-8'))
+    const privateKey = hexToBytes(hex)
+    return {
+      privateKey,
+      ethAddress: deriveEthAddress(privateKey),
+      publicKeyHex: bytesToHex(secp.getPublicKey(privateKey, true)),
+    }
+  }
+
+  const privateKey = secp.utils.randomPrivateKey()
+  fs.writeFileSync(keyPath(), JSON.stringify({ hex: bytesToHex(privateKey) }))
+  return {
+    privateKey,
+    ethAddress: deriveEthAddress(privateKey),
+    publicKeyHex: bytesToHex(secp.getPublicKey(privateKey, true)),
+  }
+}
+
+// ─── Contact persistence ────────────────────────────────────────
+
+function loadContacts(): ContactStore {
+  try {
+    return ContactStore.from(JSON.parse(fs.readFileSync(contactsPath(), 'utf-8')))
+  } catch {
+    return new ContactStore()
+  }
+}
+
+function saveContacts(store: ContactStore): void {
+  fs.writeFileSync(contactsPath(), JSON.stringify(store.export(), null, 2))
+}
+
+// ─── Block tracking ─────────────────────────────────────────────
+
+function loadLastBlock(): number {
+  try { return parseInt(fs.readFileSync(blockPath(), 'utf-8')) } catch { return 0 }
+}
+
+function saveLastBlock(block: number): void {
+  fs.writeFileSync(blockPath(), String(block))
+}
+
+// ─── NotifyProvider (read-only, raw fetch) ──────────────────────
+
+function createProvider(): NotifyProvider {
+  async function rpc(method: string, params: unknown[]): Promise<unknown> {
+    const res = await fetch(GNOSIS_RPC, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    })
+    const json = (await res.json()) as { result?: unknown; error?: { message: string } }
+    if (json.error) throw new Error(`RPC: ${json.error.message}`)
+    return json.result
+  }
+
+  return {
+    async getLogs(filter) {
+      const result = (await rpc('eth_getLogs', [{
+        address: filter.address,
+        topics: filter.topics,
+        fromBlock: '0x' + filter.fromBlock.toString(16),
+        toBlock: filter.toBlock === 'latest' || !filter.toBlock ? 'latest' : '0x' + filter.toBlock.toString(16),
+      }])) as { data: string; blockNumber: string }[]
+      return result.map(l => ({ data: l.data, blockNumber: parseInt(l.blockNumber, 16) }))
+    },
+    async call(tx) { return (await rpc('eth_call', [tx, 'latest'])) as string },
+    async sendTransaction() { throw new Error('Read-only provider') },
+  }
+}
+
+// ─── Message handler ────────────────────────────────────────────
+
+async function handleMessage(
+  bee: Bee,
+  stamp: string,
+  privateKey: Uint8Array,
+  ethAddress: string,
+  contact: Contact,
+  msg: Message,
+): Promise<void> {
+  console.log(`  [${new Date(msg.ts).toLocaleTimeString()}] ${msg.subject}: ${msg.body}`)
+
+  // Auto-respond (echo)
+  if (!msg.subject.startsWith('ack:')) {
+    console.log(`  → Auto-responding to ${contact.nickname}...`)
+    try {
+      await mailbox.send(
+        bee, '0x' + bytesToHex(privateKey), stamp, privateKey, ethAddress, contact,
+        { subject: `ack: ${msg.subject}`, body: `Received your message at ${new Date().toISOString()}` },
+      )
+    } catch (err) {
+      console.warn(`  → Failed to respond: ${err instanceof Error ? err.message : err}`)
+    }
+  }
+}
+
+// ─── Main loop ──────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  ensureDataDir()
+
+  if (!STAMP) {
+    console.error('STAMP env var is required. Set it to a usable postage batch ID.')
+    process.exit(1)
+  }
+
+  const bee = new Bee(BEE_URL)
+  const provider = createProvider()
+  const { privateKey, ethAddress, publicKeyHex } = loadOrCreateKey()
+  const signerHex = '0x' + bytesToHex(privateKey)
+
+  console.log(`Agent ETH address: ${ethAddress}`)
+  console.log(`Bee: ${BEE_URL} | Contract: ${CONTRACT}`)
+  console.log(`Poll interval: ${POLL_INTERVAL / 1000}s`)
+
+  // Publish identity on startup
+  try {
+    await identity.publish(bee, signerHex, STAMP, {
+      walletPublicKey: publicKeyHex,
+      beePublicKey: publicKeyHex,
+      ethAddress,
+    })
+    console.log('Identity published.')
+  } catch (err) {
+    console.error('Failed to publish identity:', err instanceof Error ? err.message : err)
+    process.exit(1)
+  }
+
+  const contacts = loadContacts()
+  console.log(`Loaded ${contacts.list().length} contact(s). Polling...`)
+
+  // Poll loop
+  while (true) {
+    try {
+      // 1. Check for new contacts via registry
+      const fromBlock = loadLastBlock()
+      const notifications = await registry.pollNotifications(
+        provider, CONTRACT, ethAddress, privateKey, fromBlock,
+      )
+      for (const { payload, blockNumber } of notifications) {
+        console.log(`New contact: ${payload.sender} (block ${blockNumber})`)
+        const id = await identity.resolve(bee, payload.sender)
+        if (id) {
+          try {
+            contacts.add(payload.sender, payload.sender.slice(0, 10), id)
+            saveContacts(contacts)
+          } catch { /* already exists */ }
+        }
+        saveLastBlock(blockNumber + 1)
+      }
+
+      // 2. Check inbox across all contacts
+      const allContacts = contacts.list()
+      if (allContacts.length > 0) {
+        const inbox = await mailbox.checkInbox(bee, privateKey, ethAddress, allContacts)
+        for (const { contact, messages } of inbox) {
+          console.log(`Messages from ${contact.nickname}:`)
+          for (const msg of messages) {
+            await handleMessage(bee, STAMP, privateKey, ethAddress, contact, msg)
+          }
+        }
+      }
+    } catch (err) {
+      console.error('Poll error:', err instanceof Error ? err.message : err)
+    }
+
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL))
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err)
+  process.exit(1)
+})

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -14,10 +14,13 @@
       <strong>How discovery works:</strong>
       If you already know someone's ETH address (shared via chat, website, QR code), you can look up their
       public keys on Swarm and start messaging immediately — <strong>no blockchain needed</strong>.
-      The on-chain notification registry (steps 6) is only for <em>first-contact discovery</em>:
+      The on-chain notification registry (steps 7–8) is only for <em>first-contact discovery</em>:
       when a stranger sends you a message and you need a way to find out they exist. Think of it like
       email vs. a phone book — you can email someone directly if you have their address, but the phone book
       helps strangers find you.
+      <br/><br/>
+      <strong>Multi-device:</strong> Same wallet on multiple devices shares the same inbox — feed topics are
+      derived from ETH address, not from the Bee node. Switch devices without losing your conversations.
     </div>
     <div class="config">
       <label>Bee URL <input id="cfg-bee" type="text" value="http://localhost:1633" /></label>
@@ -435,7 +438,46 @@
     <div class="bob-side">
       <div class="spacer-cell"><span class="spacer-hint">reply sent in step 9</span></div>
     </div>
+
+    <!-- Conclusion -->
+    <div class="alice-side conclusion-cell">
+      <div class="conclusion-box">
+        <strong>Conversation established.</strong> Alice and Bob can now exchange messages
+        using only steps 5–6 and 9–10 — no further identity or registry setup needed.
+        For autonomous agents, see the <a href="https://github.com/GasperX93/swarm-notify/blob/development/docs/agent-integration.md">agent integration guide</a>.
+      </div>
+    </div>
+    <div class="bob-side conclusion-cell">
+      <div class="conclusion-box">
+        <strong>Source code:</strong>
+        <a href="https://github.com/GasperX93/swarm-notify/blob/development/src/identity.ts">identity.ts</a> ·
+        <a href="https://github.com/GasperX93/swarm-notify/blob/development/src/mailbox.ts">mailbox.ts</a> ·
+        <a href="https://github.com/GasperX93/swarm-notify/blob/development/src/registry.ts">registry.ts</a> ·
+        <a href="https://github.com/GasperX93/swarm-notify/blob/development/src/crypto.ts">crypto.ts</a>
+      </div>
+    </div>
   </main>
+
+  <!-- ─── Troubleshooting ──────────────────────────── -->
+  <section class="troubleshooting">
+    <h3>Troubleshooting</h3>
+    <dl>
+      <dt>"Cannot connect to Bee"</dt>
+      <dd>Check that your Bee node is running at the configured URL. Light mode is sufficient: <code>bee start --bee-mode light</code></dd>
+
+      <dt>"No usable stamp"</dt>
+      <dd>Buy a postage stamp: <code>curl -s -X POST http://localhost:1633/stamps/10000000/20</code> (amount/depth). Or check <code>http://localhost:1633/stamps</code> for existing batches.</dd>
+
+      <dt>CORS errors in browser console</dt>
+      <dd>Start Bee with CORS enabled: <code>bee start --cors-allowed-origins '*'</code></dd>
+
+      <dt>"Insufficient funds" on Notify step</dt>
+      <dd>The on-chain notification requires xDAI on Gnosis Chain. Paste a funded private key in the "Funded Key" config field. In production, apps use the Bee node's wallet.</dd>
+
+      <dt>Notification confirmation timeout</dt>
+      <dd>The transaction was likely sent but the RPC is slow to confirm. Bob can try polling — the notification may already be on-chain.</dd>
+    </dl>
+  </section>
 
   <footer>
     <div class="log-header">

--- a/examples/web/style.css
+++ b/examples/web/style.css
@@ -732,6 +732,65 @@ footer {
   color: var(--accent);
 }
 
+/* ─── Conclusion ─────────────────────────────── */
+
+.conclusion-box {
+  background: var(--surface);
+  border: 1px solid var(--accent-dim);
+  border-radius: var(--radius);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  line-height: 1.6;
+}
+
+.conclusion-box strong { color: var(--accent); }
+.conclusion-box a { color: var(--accent); text-decoration: none; }
+.conclusion-box a:hover { text-decoration: underline; }
+
+/* ─── Troubleshooting ────────────────────────── */
+
+.troubleshooting {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.troubleshooting h3 {
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
+.troubleshooting dl {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.troubleshooting dt {
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--text);
+}
+
+.troubleshooting dd {
+  margin: 0 0 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  line-height: 1.5;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.troubleshooting dd:last-child { border-bottom: none; }
+
+.troubleshooting code {
+  background: var(--card);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: var(--accent);
+}
+
 /* ─── Responsive ─────────────────────────────── */
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary

### Agent developer documentation
- **Agent integration guide** (`docs/agent-integration.md`) — key management, automated polling with block tracking, headless Node.js setup, identity lifecycle, error recovery (Bee restarts, tx failures, stamp expiry)
- **Communication patterns** — request/response, pub/sub via registry, drive sharing, multi-agent coordination (fan-out/fan-in)
- **Polling agent example** (`examples/agent/`) — runnable template with key persistence, polling loop, auto-respond, contact/block tracking

### Web UI polish
- Fix stale step reference in overview box (was "steps 6", now "steps 7–8")
- Multi-device note: same wallet = same inbox across devices
- Conclusion cards after step 10 with source code links to library modules
- Troubleshooting section: Bee connection, stamps, CORS, funding, timeouts
- CLAUDE.md maintenance checklist updated to include agent docs

## Test plan
- [x] Playwright tests — 5 pass
- [x] Vite build — clean
- [x] Unit tests — 71 pass

Closes #47, #48, #49, #50, #51, #52.