### PR TITLE
Append-only mailbox feed — fix rapid-send message loss (#55)

### DIFF
--- a/src/mailbox.ts
+++ b/src/mailbox.ts
@@ -146,15 +146,29 @@ export async function send(
  * Decrypt a single message stored at one feed index.
  * Returns null when the index is absent OR doesn't hold a single Message object
  * (e.g. a legacy single-slot blob, which was an array — clean-break: ignored).
+ *
+ * IMPORTANT: each feed update stores a *reference* to the encrypted blob (the
+ * send path uses `uploadReference`), not the blob inline. bee-js's
+ * `downloadPayload({ index })` returns the raw single-owner-chunk payload — i.e.
+ * the reference bytes — WITHOUT resolving it (only the no-index "latest" read
+ * goes through the `/feeds` endpoint that resolves server-side). So we must
+ * follow the reference ourselves: read the reference at this index, then
+ * download the blob it points to.
  */
 async function readMessageAt(
+  bee: Bee,
   reader: ReturnType<Bee['makeFeedReader']>,
   index: number,
   sharedSecret: Uint8Array,
 ): Promise<Message | null> {
   try {
-    const result = await reader.downloadPayload({ index })
-    const encryptedBytes = result.payload.toUint8Array()
+    const { reference } = await reader.downloadReference({ index })
+    const downloaded = await bee.downloadData(reference)
+    // Real Bee returns a `Bytes` (toUint8Array); the test mock returns `{ data }`.
+    const encryptedBytes =
+      typeof (downloaded as { toUint8Array?: () => Uint8Array }).toUint8Array === 'function'
+        ? (downloaded as { toUint8Array: () => Uint8Array }).toUint8Array()
+        : (downloaded as unknown as { data: Uint8Array }).data
 
     const nonce = encryptedBytes.slice(0, 12)
     const ciphertext = encryptedBytes.slice(12)
@@ -205,7 +219,7 @@ export async function readMessages(
   const messages: Message[] = []
 
   for (let index = fromIndex; ; index++) {
-    const msg = await readMessageAt(reader, index, sharedSecret)
+    const msg = await readMessageAt(bee, reader, index, sharedSecret)
     if (!msg) break
     messages.push(msg)
   }

--- a/src/mailbox.ts
+++ b/src/mailbox.ts
@@ -7,6 +7,29 @@ import type { Contact, Message } from './types'
 const FEED_SUFFIX = 'swarm-notify'
 
 /**
+ * Append-only mailbox.
+ *
+ * Each message is written to its OWN immutable feed index instead of rewriting
+ * a single slot that holds the whole conversation. The decisive property is
+ * that the write index comes from a SENDER-CONTROLLED counter, never from a
+ * network read-latest — otherwise the overwrite race just relocates from the
+ * array layer to the index layer (a rapid second send reads a not-yet-retrievable
+ * head, gets the same index, and overwrites the first message).
+ *
+ * Index resolution priority (see `resolveNextIndex`):
+ *   1. `nextIndex` passed by the host  — authoritative, O(1), zero network read
+ *   2. in-session cache (`+1` from the last write this session)
+ *   3. cold start: discover the tail from the feed (first-ever send / lost cursor)
+ *
+ * Durable cursors are HOST-owned. The session cache below is a within-session
+ * optimization ONLY and is never persisted — persisting it would create a
+ * second source of truth that desyncs from the host's cursor.
+ */
+
+/** topic -> next index to write this session. NOT persisted (host owns durable cursors). */
+const sessionNextIndex = new Map<string, number>()
+
+/**
  * Compute the deterministic mailbox feed topic for a sender-recipient pair.
  * Topic: keccak256(senderEthAddress + recipientEthAddress + "swarm-notify")
  *
@@ -19,44 +42,48 @@ export function feedTopic(senderEthAddress: string, recipientEthAddress: string)
 }
 
 /**
- * Read existing messages from a mailbox feed. Returns empty array if feed doesn't exist.
+ * Resolve the index to write the next message to, race-free.
+ *
+ * Prefers caller-supplied / session-cached state (no network read). Only falls
+ * back to discovering the feed tail when neither is available (cold start).
  */
-async function readFeedMessages(
+async function resolveNextIndex(
   bee: Bee,
   topic: string,
   ownerAddress: string,
-  sharedSecret: Uint8Array,
-): Promise<Message[]> {
+  nextIndex?: number,
+): Promise<number> {
+  if (typeof nextIndex === 'number') return nextIndex
+
+  const cached = sessionNextIndex.get(topic)
+  if (cached !== undefined) return cached
+
+  // Cold start — discover the tail from the latest feed update.
   try {
     const reader = bee.makeFeedReader(topic, ownerAddress)
-    const result = await reader.downloadPayload()
-    const encryptedBytes = result.payload.toUint8Array()
+    const latest = await reader.downloadPayload()
+    if (latest.feedIndexNext) return Number(latest.feedIndexNext.toBigInt())
 
-    // Split nonce (first 12 bytes) and ciphertext (rest)
-    const nonce = encryptedBytes.slice(0, 12)
-    const ciphertext = encryptedBytes.slice(12)
-
-    const decryptedBytes = await decrypt({ ciphertext, nonce }, sharedSecret)
-    const json = new TextDecoder().decode(decryptedBytes)
-    return JSON.parse(json) as Message[]
+    return Number(latest.feedIndex.toBigInt()) + 1
   } catch {
-    // Feed not found or decrypt failure — return empty
-    return []
+    // Feed doesn't exist yet — start at 0.
+    return 0
   }
 }
 
 /**
  * Send an encrypted message to a contact.
  *
- * Steps:
- * 1. Derive shared secret via ECDH (my private key + their public key)
- * 2. Read existing messages from my→them feed (if any)
- * 3. Append new message to array
- * 4. Encrypt full array with AES-256-GCM
- * 5. Upload encrypted blob to Swarm
- * 6. Update mailbox feed to point to new blob
+ * Writes ONE encrypted chunk at a sender-controlled index (no read-modify-write,
+ * so nothing can overwrite). Returns the index written so the host can advance
+ * its durable cursor to `index + 1`.
  *
- * @param signer - Private key hex string or Uint8Array for feed signing
+ * @param signer    - Private key hex string or Uint8Array for feed signing
+ * @param nextIndex - Optional explicit index to write at. When the host passes
+ *                    its durable cursor here, sends are O(1) and race-free by
+ *                    construction. Omit it and the library uses a session cache
+ *                    (then cold-start discovery) — convenient for naive callers.
+ * @returns the feed index the message was written to
  */
 export async function send(
   bee: Bee,
@@ -66,7 +93,8 @@ export async function send(
   myEthAddress: string,
   recipient: Contact,
   message: Omit<Message, 'v' | 'ts' | 'sender'>,
-): Promise<void> {
+  nextIndex?: number,
+): Promise<number> {
   // Derive shared secret
   const recipientPubKeyBytes = hexToBytes(recipient.walletPublicKey)
   const sharedSecret = deriveSharedSecret(myPrivateKey, recipientPubKeyBytes)
@@ -74,24 +102,22 @@ export async function send(
   // Compute feed topic (my ethAddress → their ethAddress)
   const topic = feedTopic(myEthAddress, recipient.ethAddress)
 
-  // Get the writer's ETH address for reading existing messages
+  // The writer's own ETH address — also the owner we read tail from on cold start.
   const writer = bee.makeFeedWriter(topic, signer)
   const ownerAddress = writer.owner.toHex()
 
-  // Read existing messages from this feed
-  const existing = await readFeedMessages(bee, topic, ownerAddress, sharedSecret)
+  const index = await resolveNextIndex(bee, topic, ownerAddress, nextIndex)
 
-  // Append new message
+  // Build the single message
   const fullMessage: Message = {
     v: 1,
     ...message,
     ts: Date.now(),
     sender: myEthAddress,
   }
-  existing.push(fullMessage)
 
-  // Encrypt the full array
-  const plaintext = new TextEncoder().encode(JSON.stringify(existing))
+  // Encrypt JUST this one message (not the whole history)
+  const plaintext = new TextEncoder().encode(JSON.stringify(fullMessage))
   const encrypted = await encrypt(plaintext, sharedSecret)
 
   // Pack as [nonce (12) | ciphertext]
@@ -99,34 +125,95 @@ export async function send(
   blob.set(encrypted.nonce, 0)
   blob.set(encrypted.ciphertext, 12)
 
-  // Upload encrypted blob and update feed
+  // Upload the blob, then point THIS feed index at it.
   const uploadResult = await bee.uploadData(stamp, blob)
-  await writer.uploadReference(stamp, uploadResult.reference)
+  await writer.uploadReference(stamp, uploadResult.reference, { index })
+
+  // Advance the session cache so a follow-up send this session is race-free
+  // even when the host doesn't pass a cursor.
+  sessionNextIndex.set(topic, index + 1)
+
+  return index
 }
 
 /**
- * Read all messages from a specific contact's mailbox feed.
- * Reads the contact→me feed (contact is the sender/owner).
+ * Decrypt a single message stored at one feed index.
+ * Returns null when the index is absent OR doesn't hold a single Message object
+ * (e.g. a legacy single-slot blob, which was an array — clean-break: ignored).
+ */
+async function readMessageAt(
+  reader: ReturnType<Bee['makeFeedReader']>,
+  index: number,
+  sharedSecret: Uint8Array,
+): Promise<Message | null> {
+  try {
+    const result = await reader.downloadPayload({ index })
+    const encryptedBytes = result.payload.toUint8Array()
+
+    const nonce = encryptedBytes.slice(0, 12)
+    const ciphertext = encryptedBytes.slice(12)
+
+    const decryptedBytes = await decrypt({ ciphertext, nonce }, sharedSecret)
+    const parsed = JSON.parse(new TextDecoder().decode(decryptedBytes)) as unknown
+
+    // New format = one Message object per index. A legacy array (old single-slot
+    // format) is intentionally ignored → yields [] for that thread (clean break).
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+
+    return parsed as Message
+  } catch {
+    // Index not yet retrievable, missing, or decrypt failure.
+    return null
+  }
+}
+
+/**
+ * Read messages from a contact's mailbox feed (the contact→me feed) starting at
+ * `fromIndex`, in index order.
+ *
+ * Stops at the FIRST gap (an index that can't be read). Because the sender
+ * writes indices contiguously and pins each chunk, a gap is a transient
+ * not-yet-propagated chunk, not a permanent hole — so stopping preserves strict
+ * ordering and the missing messages are picked up on a later poll, once the
+ * lagging chunk propagates. (Skipping a gap would deliver later messages out of
+ * order, which is worse for a chat.)
+ *
+ * @param fromIndex - First index to read (host passes its read cursor here for
+ *                    O(1) incremental reads). Defaults to 0 = full history.
  */
 export async function readMessages(
   bee: Bee,
   myPrivateKey: Uint8Array,
   myEthAddress: string,
   contact: Contact,
+  fromIndex = 0,
 ): Promise<Message[]> {
   // Derive shared secret
   const contactPubKeyBytes = hexToBytes(contact.walletPublicKey)
   const sharedSecret = deriveSharedSecret(myPrivateKey, contactPubKeyBytes)
 
-  // Topic: contact→me (contact is sender)
+  // Topic: contact→me (contact is the sender/owner)
   const topic = feedTopic(contact.ethAddress, myEthAddress)
+  const reader = bee.makeFeedReader(topic, contact.ethAddress)
 
-  // The feed owner is the contact's ETH address
-  return readFeedMessages(bee, topic, contact.ethAddress, sharedSecret)
+  const messages: Message[] = []
+
+  for (let index = fromIndex; ; index++) {
+    const msg = await readMessageAt(reader, index, sharedSecret)
+    if (!msg) break
+    messages.push(msg)
+  }
+
+  return messages
 }
 
 /**
  * Check inbox across all contacts. Returns messages per contact.
+ *
+ * v1 reads each contact from index 0 — incremental (per-contact cursor) reads
+ * are a host-cursor concern; `checkInbox` holds no per-contact state, so the
+ * host should call `readMessages(..., fromIndex)` directly when it wants O(1)
+ * incremental polling.
  */
 export async function checkInbox(
   bee: Bee,

--- a/src/mailbox.ts
+++ b/src/mailbox.ts
@@ -4,7 +4,13 @@ import { deriveSharedSecret, encrypt, decrypt } from './crypto'
 import type { Bee } from '@ethersphere/bee-js'
 import type { Contact, Message } from './types'
 
-const FEED_SUFFIX = 'swarm-notify'
+// Bumped to v2 with the append-only format. The v1 ('swarm-notify') feeds held
+// the whole conversation as one mutable slot; v2 writes one message per index.
+// Versioning the topic abandons v1 feeds entirely so the new format always
+// starts on a virgin feed at index 0 — a clean break with no migration and no
+// chance of a v1 array blob colliding with a v2 index. Both parties upgrade
+// together (the single-object payload is unreadable by the v1 reader anyway).
+const FEED_SUFFIX = 'swarm-notify/v2'
 
 /**
  * Append-only mailbox.

--- a/test/helpers/mock-bee.ts
+++ b/test/helpers/mock-bee.ts
@@ -16,6 +16,14 @@ function feedIndex(n: number): { toBigInt: () => bigint } {
   return { toBigInt: () => BigInt(n) }
 }
 
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < bytes.length; i++) bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+
+  return bytes
+}
+
 export class MockBee {
   /** Blob storage: reference → data */
   private blobs = new Map<string, Uint8Array>()
@@ -33,11 +41,12 @@ export class MockBee {
     return { reference: { toHex: () => ref } }
   }
 
-  /** Download a previously uploaded blob by reference. */
-  async downloadData(reference: string): Promise<{ data: Uint8Array }> {
+  /** Download a previously uploaded blob by reference. Returns a `Bytes`-like
+   * (real bee-js returns a `Bytes` with `toUint8Array()`). */
+  async downloadData(reference: string): Promise<{ toUint8Array: () => Uint8Array }> {
     const data = this.blobs.get(reference)
     if (!data) throw new Error(`Blob not found: ${reference}`)
-    return { data: new Uint8Array(data) }
+    return { toUint8Array: () => new Uint8Array(data) }
   }
 
   /**
@@ -92,13 +101,32 @@ export class MockBee {
     const ownerHex = address.replace('0x', '').toLowerCase()
     const key = `${topic}:${ownerHex}`
 
+    // Resolve a mailbox feed index → its stored reference (or throw if absent).
+    const resolveRef = (requested?: number) => {
+      const latest = this.feedLatestIndex.get(key)
+      const index = requested ?? latest
+      if (index === undefined) throw new Error(`Feed not found: ${key}`)
+      const ref = this.feedReferences.get(`${key}:${index}`)
+      if (!ref) throw new Error(`Feed not found at index ${index}: ${key}`)
+      const isLatest = latest !== undefined && index === latest
+
+      return { ref, index, feedIndexNext: isLatest ? feedIndex(latest + 1) : undefined }
+    }
+
+    const toIndex = (opts?: { index?: number | { toBigInt: () => bigint } }) =>
+      opts?.index === undefined
+        ? undefined
+        : typeof opts.index === 'number'
+          ? opts.index
+          : Number(opts.index.toBigInt())
+
     return {
+      // Faithful to real bee-js: the no-index ("latest") read goes through the
+      // /feeds endpoint and RESOLVES the reference to the content; an explicit
+      // index read returns the raw single-owner-chunk payload (the reference
+      // bytes), NOT the content. So mailbox reads must use downloadReference.
       downloadPayload: async (opts?: { index?: number | { toBigInt: () => bigint } }) => {
-        const requested = opts?.index === undefined
-          ? undefined
-          : typeof opts.index === 'number'
-            ? opts.index
-            : Number(opts.index.toBigInt())
+        const requested = toIndex(opts)
 
         // Identity feeds: direct single-slot payload (only on a no-index/latest read).
         if (requested === undefined) {
@@ -109,27 +137,26 @@ export class MockBee {
               feedIndex: feedIndex(0),
             }
           }
+          // Mailbox: no-index resolves the latest reference to its content.
+          const { ref, index, feedIndexNext } = resolveRef(undefined)
+          const data = this.blobs.get(ref)
+          if (!data) throw new Error(`Blob not found: ${ref}`)
+
+          return { payload: { toUint8Array: () => new Uint8Array(data) }, feedIndex: feedIndex(index), feedIndexNext }
         }
 
-        // Mailbox reference feeds (append-only, per index).
-        const latest = this.feedLatestIndex.get(key)
-        const index = requested ?? latest
-        if (index === undefined) throw new Error(`Feed not found: ${key}`)
+        // Explicit index: return the RAW reference bytes (does NOT resolve) —
+        // mirrors real bee-js so callers can't accidentally rely on resolution.
+        const { ref, index, feedIndexNext } = resolveRef(requested)
 
-        const ref = this.feedReferences.get(`${key}:${index}`)
-        if (!ref) throw new Error(`Feed not found at index ${index}: ${key}`)
+        return { payload: { toUint8Array: () => hexToBytes(ref) }, feedIndex: feedIndex(index), feedIndexNext }
+      },
 
-        const data = this.blobs.get(ref)
-        if (!data) throw new Error(`Blob not found: ${ref}`)
+      // Returns the reference stored at an index; the caller downloads it.
+      downloadReference: async (opts?: { index?: number | { toBigInt: () => bigint } }) => {
+        const { ref, index, feedIndexNext } = resolveRef(toIndex(opts))
 
-        // feedIndexNext is only meaningful on a latest read (mimics bee-js).
-        const isLatest = latest !== undefined && index === latest
-
-        return {
-          payload: { toUint8Array: () => new Uint8Array(data) },
-          feedIndex: feedIndex(index),
-          feedIndexNext: isLatest ? feedIndex(latest + 1) : undefined,
-        }
+        return { reference: ref, feedIndex: feedIndex(index), feedIndexNext }
       },
     }
   }

--- a/test/helpers/mock-bee.ts
+++ b/test/helpers/mock-bee.ts
@@ -1,17 +1,30 @@
 /**
  * In-memory Bee mock for integration tests.
  * Stores blobs and feed pointers in Maps so read-after-write works.
+ *
+ * Mailbox feeds are now APPEND-ONLY: each index is a separate slot, so the mock
+ * keys references by `topic:owner:index` and tracks the latest index per feed
+ * (to mimic bee-js `feedIndex` / `feedIndexNext` on a latest read). Identity
+ * feeds still use the direct-payload path (single slot, no index).
  */
 
 import { keccak_256 } from '@noble/hashes/sha3'
 import { bytesToHex } from '@noble/hashes/utils'
 
+/** Minimal stand-in for bee-js FeedIndex (only `toBigInt` is used by the SDK). */
+function feedIndex(n: number): { toBigInt: () => bigint } {
+  return { toBigInt: () => BigInt(n) }
+}
+
 export class MockBee {
   /** Blob storage: reference → data */
   private blobs = new Map<string, Uint8Array>()
-  /** Feed storage: "topic:owner" → payload (Uint8Array) or reference (string) */
+  /** Direct feed payloads (identity feeds): "topic:owner" → payload */
   private feedPayloads = new Map<string, Uint8Array>()
+  /** Reference feeds (mailbox), per index: "topic:owner:index" → reference */
   private feedReferences = new Map<string, string>()
+  /** Latest written index per mailbox feed: "topic:owner" → index */
+  private feedLatestIndex = new Map<string, number>()
 
   /** Upload data blob. Returns a deterministic reference (hash of data). */
   async uploadData(_stamp: string, data: Uint8Array): Promise<{ reference: { toHex: () => string } }> {
@@ -32,55 +45,91 @@ export class MockBee {
    * The signer is used as the owner address (simplified for testing).
    */
   makeFeedWriter(topic: string, signer: string | Uint8Array) {
-    const ownerHex = typeof signer === 'string'
+    const ownerHex = (typeof signer === 'string'
       ? signer.replace('0x', '').slice(0, 40)
       : bytesToHex(signer).slice(0, 40)
+    ).toLowerCase()
 
     const key = `${topic}:${ownerHex}`
 
     return {
       owner: { toHex: () => ownerHex },
 
-      /** Upload raw payload to the feed (used by identity.publish). */
+      /** Upload raw payload to the feed (used by identity.publish — single slot). */
       uploadPayload: async (_stamp: string, payload: Uint8Array) => {
         this.feedPayloads.set(key, new Uint8Array(payload))
         return { reference: 'feed-' + key }
       },
 
-      /** Upload a reference to the feed (used by mailbox.send). */
-      uploadReference: async (_stamp: string, reference: { toHex?: () => string } | string) => {
+      /** Upload a reference at a specific index (used by mailbox.send — append-only). */
+      uploadReference: async (
+        _stamp: string,
+        reference: { toHex?: () => string } | string,
+        opts?: { index?: number | { toBigInt: () => bigint } },
+      ) => {
         const ref = typeof reference === 'string' ? reference : reference.toHex!()
-        this.feedReferences.set(key, ref)
+        const index = opts?.index === undefined
+          ? 0
+          : typeof opts.index === 'number'
+            ? opts.index
+            : Number(opts.index.toBigInt())
+
+        this.feedReferences.set(`${key}:${index}`, ref)
+
+        const prev = this.feedLatestIndex.get(key)
+        if (prev === undefined || index > prev) this.feedLatestIndex.set(key, index)
+
+        return { reference: ref }
       },
     }
   }
 
   /**
    * Create a feed reader for a topic + owner address.
-   * Returns the last payload or referenced blob.
+   * Honors an explicit `index`; with no index returns the latest update.
    */
   makeFeedReader(topic: string, address: string) {
     const ownerHex = address.replace('0x', '').toLowerCase()
     const key = `${topic}:${ownerHex}`
 
     return {
-      downloadPayload: async () => {
-        // First check for direct payload (identity feeds)
-        const directPayload = this.feedPayloads.get(key)
-        if (directPayload) {
-          return { payload: { toUint8Array: () => new Uint8Array(directPayload) } }
-        }
+      downloadPayload: async (opts?: { index?: number | { toBigInt: () => bigint } }) => {
+        const requested = opts?.index === undefined
+          ? undefined
+          : typeof opts.index === 'number'
+            ? opts.index
+            : Number(opts.index.toBigInt())
 
-        // Then check for reference-based payload (mailbox feeds)
-        const ref = this.feedReferences.get(key)
-        if (ref) {
-          const data = this.blobs.get(ref)
-          if (data) {
-            return { payload: { toUint8Array: () => new Uint8Array(data) } }
+        // Identity feeds: direct single-slot payload (only on a no-index/latest read).
+        if (requested === undefined) {
+          const directPayload = this.feedPayloads.get(key)
+          if (directPayload) {
+            return {
+              payload: { toUint8Array: () => new Uint8Array(directPayload) },
+              feedIndex: feedIndex(0),
+            }
           }
         }
 
-        throw new Error(`Feed not found: ${key}`)
+        // Mailbox reference feeds (append-only, per index).
+        const latest = this.feedLatestIndex.get(key)
+        const index = requested ?? latest
+        if (index === undefined) throw new Error(`Feed not found: ${key}`)
+
+        const ref = this.feedReferences.get(`${key}:${index}`)
+        if (!ref) throw new Error(`Feed not found at index ${index}: ${key}`)
+
+        const data = this.blobs.get(ref)
+        if (!data) throw new Error(`Blob not found: ${ref}`)
+
+        // feedIndexNext is only meaningful on a latest read (mimics bee-js).
+        const isLatest = latest !== undefined && index === latest
+
+        return {
+          payload: { toUint8Array: () => new Uint8Array(data) },
+          feedIndex: feedIndex(index),
+          feedIndexNext: isLatest ? feedIndex(latest + 1) : undefined,
+        }
       },
     }
   }
@@ -90,5 +139,6 @@ export class MockBee {
     this.blobs.clear()
     this.feedPayloads.clear()
     this.feedReferences.clear()
+    this.feedLatestIndex.clear()
   }
 }

--- a/test/mailbox.test.ts
+++ b/test/mailbox.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import * as secp from '@noble/secp256k1'
 import { bytesToHex } from '@noble/hashes/utils'
 import { feedTopic, send, readMessages, checkInbox } from '../src/mailbox'
+import { deriveSharedSecret, encrypt } from '../src/crypto'
+import { MockBee } from './helpers/mock-bee'
 import type { Contact } from '../src/types'
+
+const STAMP = 'stamp123'
 
 // Helper: create a key pair and return { privateKey, publicKeyHex, address }
 function makeKeypair() {
@@ -26,17 +30,22 @@ function makeContact(keypair: ReturnType<typeof makeKeypair>): Contact {
   }
 }
 
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
 describe('feedTopic', () => {
   it('deterministic for same pair', () => {
-    const a = 'aaaa'
-    const b = 'bbbb'
-    expect(feedTopic(a, b)).toBe(feedTopic(a, b))
+    expect(feedTopic('aaaa', 'bbbb')).toBe(feedTopic('aaaa', 'bbbb'))
   })
 
   it('different for reversed pair (Alice→Bob ≠ Bob→Alice)', () => {
-    const a = 'aaaa'
-    const b = 'bbbb'
-    expect(feedTopic(a, b)).not.toBe(feedTopic(b, a))
+    expect(feedTopic('aaaa', 'bbbb')).not.toBe(feedTopic('bbbb', 'aaaa'))
   })
 
   it('case-insensitive', () => {
@@ -48,61 +57,18 @@ describe('feedTopic', () => {
   })
 })
 
-describe('send + readMessages', () => {
+describe('send + readMessages (append-only)', () => {
   it('round-trip: send a message, read it back', async () => {
+    const bee = new MockBee()
     const alice = makeKeypair()
     const bob = makeKeypair()
-    const bobContact = makeContact(bob)
 
-    // Track what gets uploaded and written to feed
-    let uploadedBlob: Uint8Array | null = null
-    const uploadRef = 'abc123ref'
-
-    const uploadData = vi.fn().mockImplementation((_stamp: string, data: Uint8Array) => {
-      uploadedBlob = data
-      return { reference: { toHex: () => uploadRef } }
-    })
-    const uploadReference = vi.fn().mockResolvedValue({})
-    const ownerHex = alice.address
-    const makeFeedWriter = vi.fn().mockReturnValue({
-      owner: { toHex: () => ownerHex },
-      uploadReference,
+    await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, makeContact(bob), {
+      subject: 'Hello',
+      body: 'First message',
     })
 
-    // First send: no existing messages (feed not found)
-    const downloadPayloadFail = vi.fn().mockRejectedValue(new Error('Not found'))
-    const makeFeedReader = vi.fn().mockReturnValue({
-      downloadPayload: downloadPayloadFail,
-    })
-
-    const bee = { uploadData, makeFeedWriter, makeFeedReader } as any
-
-    await send(
-      bee,
-      '0x' + bytesToHex(alice.privateKey),
-      'stamp123',
-      alice.privateKey,
-      alice.address,
-      bobContact,
-      { subject: 'Hello', body: 'First message' },
-    )
-
-    expect(uploadData).toHaveBeenCalled()
-    expect(uploadReference).toHaveBeenCalled()
-    expect(uploadedBlob).not.toBeNull()
-
-    // Now simulate readMessages: bob reads alice's feed
-    // The feed reader should return what was uploaded
-    const downloadPayloadSuccess = vi.fn().mockResolvedValue({
-      payload: { toUint8Array: () => uploadedBlob },
-    })
-    const makeFeedReaderForRead = vi.fn().mockReturnValue({
-      downloadPayload: downloadPayloadSuccess,
-    })
-    const beeRead = { makeFeedReader: makeFeedReaderForRead } as any
-
-    const aliceContact = makeContact(alice)
-    const messages = await readMessages(beeRead, bob.privateKey, bob.address, aliceContact)
+    const messages = await readMessages(bee as any, bob.privateKey, bob.address, makeContact(alice))
 
     expect(messages).toHaveLength(1)
     expect(messages[0].subject).toBe('Hello')
@@ -112,135 +78,153 @@ describe('send + readMessages', () => {
     expect(messages[0].ts).toBeGreaterThan(0)
   })
 
-  it('send multiple messages: array grows', async () => {
+  it('send returns the monotonic index it wrote', async () => {
+    const bee = new MockBee()
     const alice = makeKeypair()
     const bob = makeKeypair()
     const bobContact = makeContact(bob)
 
-    let uploadedBlob: Uint8Array | null = null
-    const uploadData = vi.fn().mockImplementation((_stamp: string, data: Uint8Array) => {
-      uploadedBlob = data
-      return { reference: { toHex: () => 'ref' } }
-    })
-    const uploadReference = vi.fn().mockResolvedValue({})
-    const ownerHex = alice.address
-    const makeFeedWriter = vi.fn().mockReturnValue({
-      owner: { toHex: () => ownerHex },
-      uploadReference,
-    })
+    const i0 = await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, { subject: '', body: 'a' })
+    const i1 = await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, { subject: '', body: 'b' })
+    const i2 = await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, { subject: '', body: 'c' })
 
-    // First send: empty feed
-    const makeFeedReader = vi.fn().mockReturnValue({
-      downloadPayload: vi.fn().mockRejectedValue(new Error('Not found')),
-    })
-    const bee = { uploadData, makeFeedWriter, makeFeedReader } as any
+    expect([i0, i1, i2]).toEqual([0, 1, 2])
+  })
 
-    await send(bee, '0x' + bytesToHex(alice.privateKey), 'stamp', alice.privateKey, alice.address, bobContact, {
-      subject: 'Msg 1',
-      body: 'First',
-    })
+  it('multiple sequential sends accumulate in order', async () => {
+    const bee = new MockBee()
+    const alice = makeKeypair()
+    const bob = makeKeypair()
+    const bobContact = makeContact(bob)
 
-    const firstBlob = uploadedBlob!
+    for (let i = 1; i <= 3; i++) {
+      await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, {
+        subject: `Msg ${i}`,
+        body: `Body ${i}`,
+      })
+    }
 
-    // Second send: feed now returns the first blob
-    const makeFeedReader2 = vi.fn().mockReturnValue({
-      downloadPayload: vi.fn().mockResolvedValue({
-        payload: { toUint8Array: () => firstBlob },
-      }),
-    })
-    const bee2 = { uploadData, makeFeedWriter, makeFeedReader: makeFeedReader2 } as any
+    const messages = await readMessages(bee as any, bob.privateKey, bob.address, makeContact(alice))
 
-    await send(bee2, '0x' + bytesToHex(alice.privateKey), 'stamp', alice.privateKey, alice.address, bobContact, {
-      subject: 'Msg 2',
-      body: 'Second',
-    })
+    expect(messages.map(m => m.subject)).toEqual(['Msg 1', 'Msg 2', 'Msg 3'])
+  })
 
-    // Read back: should have 2 messages
-    const makeFeedReaderRead = vi.fn().mockReturnValue({
-      downloadPayload: vi.fn().mockResolvedValue({
-        payload: { toUint8Array: () => uploadedBlob },
-      }),
-    })
-    const beeRead = { makeFeedReader: makeFeedReaderRead } as any
+  // The headline regression: this is the bug #55 fixes. With the old single-slot
+  // read-modify-write, concurrent sends overwrote each other and only the last
+  // survived. Append-only with host-supplied indices is race-free by construction.
+  it('rapid CONCURRENT sends with host cursor → all delivered, in order', async () => {
+    const bee = new MockBee()
+    const alice = makeKeypair()
+    const bob = makeKeypair()
+    const bobContact = makeContact(bob)
+
+    const N = 8
+    const indices = await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, { subject: '', body: `m${i}` }, i),
+      ),
+    )
+
+    // every send landed at its own distinct index
+    expect([...indices].sort((a, b) => a - b)).toEqual(Array.from({ length: N }, (_, i) => i))
+
+    const messages = await readMessages(bee as any, bob.privateKey, bob.address, makeContact(alice))
+    expect(messages.map(m => m.body)).toEqual(Array.from({ length: N }, (_, i) => `m${i}`))
+  })
+
+  it('readMessages(fromIndex) returns only the tail', async () => {
+    const bee = new MockBee()
+    const alice = makeKeypair()
+    const bob = makeKeypair()
+    const bobContact = makeContact(bob)
+
+    for (let i = 0; i < 4; i++) {
+      await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, { subject: '', body: `m${i}` })
+    }
+
+    const tail = await readMessages(bee as any, bob.privateKey, bob.address, makeContact(alice), 2)
+    expect(tail.map(m => m.body)).toEqual(['m2', 'm3'])
+  })
+})
+
+describe('warmup / gap handling', () => {
+  it('stops at a not-yet-propagated gap, then picks it up once filled', async () => {
+    const bee = new MockBee()
+    const alice = makeKeypair()
+    const bob = makeKeypair()
+    const bobContact = makeContact(bob)
     const aliceContact = makeContact(alice)
-    const messages = await readMessages(beeRead, bob.privateKey, bob.address, aliceContact)
 
-    expect(messages).toHaveLength(2)
-    expect(messages[0].subject).toBe('Msg 1')
-    expect(messages[1].subject).toBe('Msg 2')
+    // Write indices 0, 1, 3 — index 2 hasn't propagated yet (explicit indices).
+    await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, { subject: '', body: 'm0' }, 0)
+    await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, { subject: '', body: 'm1' }, 1)
+    await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, { subject: '', body: 'm3' }, 3)
+
+    // Reader stops at the gap (index 2) — strict ordering, no out-of-order delivery.
+    const before = await readMessages(bee as any, bob.privateKey, bob.address, aliceContact)
+    expect(before.map(m => m.body)).toEqual(['m0', 'm1'])
+
+    // Gap fills in; reader now sees everything in order.
+    await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, bobContact, { subject: '', body: 'm2' }, 2)
+    const after = await readMessages(bee as any, bob.privateKey, bob.address, aliceContact)
+    expect(after.map(m => m.body)).toEqual(['m0', 'm1', 'm2', 'm3'])
   })
 })
 
 describe('readMessages edge cases', () => {
   it('returns [] on non-existent feed', async () => {
-    const bob = makeKeypair()
+    const bee = new MockBee()
     const alice = makeKeypair()
-    const makeFeedReader = vi.fn().mockReturnValue({
-      downloadPayload: vi.fn().mockRejectedValue(new Error('Not found')),
-    })
-    const bee = { makeFeedReader } as any
-    const aliceContact = makeContact(alice)
+    const bob = makeKeypair()
 
-    const messages = await readMessages(bee, bob.privateKey, bob.address, aliceContact)
+    const messages = await readMessages(bee as any, bob.privateKey, bob.address, makeContact(alice))
+    expect(messages).toEqual([])
+  })
+
+  it('clean break: a legacy single-slot ARRAY blob yields [] (no throw)', async () => {
+    const bee = new MockBee()
+    const alice = makeKeypair()
+    const bob = makeKeypair()
+
+    // Reconstruct the OLD format: the whole conversation as one encrypted array
+    // at index 0 of the alice→bob feed.
+    const sharedSecret = deriveSharedSecret(alice.privateKey, hexToBytes(bob.publicKeyHex))
+    const legacyArray = [
+      { v: 1, subject: 'old', body: 'legacy 1', ts: 1000, sender: alice.address },
+      { v: 1, subject: 'old', body: 'legacy 2', ts: 2000, sender: alice.address },
+    ]
+    const encrypted = await encrypt(new TextEncoder().encode(JSON.stringify(legacyArray)), sharedSecret)
+    const blob = new Uint8Array(12 + encrypted.ciphertext.length)
+    blob.set(encrypted.nonce, 0)
+    blob.set(encrypted.ciphertext, 12)
+
+    const topic = feedTopic(alice.address, bob.address)
+    const { reference } = await bee.uploadData(STAMP, blob)
+    await bee.makeFeedWriter(topic, alice.address).uploadReference(STAMP, reference, { index: 0 })
+
+    const messages = await readMessages(bee as any, bob.privateKey, bob.address, makeContact(alice))
     expect(messages).toEqual([])
   })
 })
 
 describe('checkInbox', () => {
-  it('aggregates messages from multiple contacts', async () => {
+  it('aggregates messages from contacts that have any, skips empty ones', async () => {
+    const bee = new MockBee()
     const me = makeKeypair()
     const alice = makeKeypair()
     const bob = makeKeypair()
 
-    // Simulate: alice sent me a message, bob's feed is empty
-    // We need to create encrypted blobs for alice's messages
-    const { deriveSharedSecret, encrypt } = await import('../src/crypto')
-    const alicePubBytes = hexToBytes(alice.publicKeyHex)
-    const sharedWithAlice = deriveSharedSecret(me.privateKey, alicePubBytes)
-
-    const aliceMessages = [{ v: 1, subject: 'Hi', body: 'From Alice', ts: 1000, sender: alice.address }]
-    const plaintext = new TextEncoder().encode(JSON.stringify(aliceMessages))
-    const encrypted = await encrypt(plaintext, sharedWithAlice)
-    const blob = new Uint8Array(12 + encrypted.ciphertext.length)
-    blob.set(encrypted.nonce, 0)
-    blob.set(encrypted.ciphertext, 12)
-
-    let callCount = 0
-    const makeFeedReader = vi.fn().mockImplementation(() => {
-      callCount++
-      if (callCount === 1) {
-        // Alice's feed — has messages
-        return {
-          downloadPayload: vi.fn().mockResolvedValue({
-            payload: { toUint8Array: () => blob },
-          }),
-        }
-      }
-      // Bob's feed — empty
-      return {
-        downloadPayload: vi.fn().mockRejectedValue(new Error('Not found')),
-      }
+    // Alice sends me a message; Bob never does.
+    await send(bee as any, alice.address, STAMP, alice.privateKey, alice.address, makeContact(me), {
+      subject: 'Hi',
+      body: 'From Alice',
     })
-    const bee = { makeFeedReader } as any
 
-    const aliceContact = makeContact(alice)
-    const bobContact = makeContact(bob)
+    const inbox = await checkInbox(bee as any, me.privateKey, me.address, [makeContact(alice), makeContact(bob)])
 
-    const inbox = await checkInbox(bee, me.privateKey, me.address, [aliceContact, bobContact])
-
-    // Only Alice should appear (Bob has no messages)
     expect(inbox).toHaveLength(1)
-    expect(inbox[0].contact.ethAddress).toBe(aliceContact.ethAddress)
+    expect(inbox[0].contact.ethAddress).toBe(alice.address)
     expect(inbox[0].messages).toHaveLength(1)
     expect(inbox[0].messages[0].subject).toBe('Hi')
   })
 })
-
-function hexToBytes(hex: string): Uint8Array {
-  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
-  const bytes = new Uint8Array(clean.length / 2)
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
-  }
-  return bytes
-}


### PR DESCRIPTION
Closes #55.

Replaces the single-slot read-modify-write mailbox with an **append-only feed** (one message = one immutable index), fixing rapid/concurrent-send message loss.

## What changed
- **`send(...)` → `Promise<number>`** — writes one encrypted chunk at a sender-controlled index and returns it. Index resolution: host-passed `nextIndex` → in-session cache (`+1`) → cold-start tail discovery (`feedIndexNext`). No read-modify-write.
- **`readMessages(..., fromIndex = 0)`** — walks indices in order, **stops at the first gap** (transient un-propagated chunk is picked up on a later poll; strict ordering, no out-of-order delivery).
- **Feed topic versioned** `swarm-notify` → `swarm-notify/v2` — abandons v1 single-slot feeds so the new format starts on virgin feeds at index 0. Clean break, no migration, no v1-array/v2-index collision.
- Legacy v1 array blobs (if ever read) decrypt to a non-object → ignored → `[]`.

## Design (ergonomic B)
The decisive property: the write index comes from a **sender-controlled counter, never a network read-latest** — otherwise the overwrite race just relocates to the index layer. Durable cursors stay **host-owned**; the SDK's session cache is within-session only and never persisted.

## API compatibility
Additive only — new optional trailing params (`nextIndex`, `fromIndex`) and a meaningful return value. Existing callers (incl. `examples/`) compile and run unchanged.

## Tests
- **76/76 unit tests pass**, incl. the headline regression: **8 concurrent sends → all delivered, in order** (fails on `development` today).
- Gap handling, `fromIndex` cursor, legacy-array clean break, `send`-returns-index. `tsc --noEmit` clean.

## Follow-ups (not in this PR)
- #56 — recipient-ack read receipts (honest delivery status).
- Docs/examples polish to demonstrate the host-cursor pattern.

> Note: repo `lint:check` is pre-broken on `development` (no `eslint.config.js`, no prettier config) — unrelated to this PR.
